### PR TITLE
conda install pip

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -16,6 +16,7 @@ We recommend having a designated environment, for example with conda:
 
    conda create -n imswitch python=3.8
    conda activate imswitch
+   conda install pip
    cd /path_of_imswitch
    pip install -r requirements.txt
 


### PR DESCRIPTION
A brand new conda environment doesn't have Python or pip installed. The instructions as written would likely have the user accidentally install the dependencies to their base environment.