### PR TITLE
Ximea integration

### DIFF
--- a/imswitch/imcontrol/_test/unit/__init__.py
+++ b/imswitch/imcontrol/_test/unit/__init__.py
@@ -79,6 +79,27 @@ detectorInfosNonSquare = {
     )
 }
 
+detectorInfoXimea = {
+    'CAM' : DetectorInfo(
+        analogChannel=None,
+        digitalLine=3,
+        managerName="XimeaManager",
+        managerProperties={
+            "cameraListIndex" : 0,
+            "ximea" : {
+                "exposure" : 100,
+                "offsetX" : 0,
+                "offsetY" : 0,
+                "width" : 1280,
+				"height" : 864,
+				"trigger_source" : "XI_TRG_OFF",
+				"gpi_selector" : "XI_GPI_PORT1"
+            }
+        },
+        forAcquisition=True
+    )
+}
+
 
 # Copyright (C) 2020, 2021 TestaLab
 # This file is part of ImSwitch.

--- a/imswitch/imcontrol/_test/unit/test_recording.py
+++ b/imswitch/imcontrol/_test/unit/test_recording.py
@@ -3,7 +3,7 @@ import pytest
 import h5py
 
 from imswitch.imcontrol.model import DetectorsManager, RecordingManager, RecMode, SaveMode
-from . import detectorInfosBasic, detectorInfosMulti, detectorInfosNonSquare
+from . import detectorInfosBasic, detectorInfosMulti, detectorInfosNonSquare, detectorInfoXimea
 
 
 def record(qtbot, detectorInfos, *args, **kwargs):
@@ -31,7 +31,7 @@ def record(qtbot, detectorInfos, *args, **kwargs):
 
 
 @pytest.mark.parametrize('detectorInfos,numFrames',
-                         [(detectorInfosBasic, 10), (detectorInfosNonSquare, 53)])
+                         [(detectorInfosBasic, 10), (detectorInfosNonSquare, 53), (detectorInfoXimea, 510)])
 def test_recording_spec_frames(qtbot, detectorInfos, numFrames):
     filePerDetector, savedToDiskPerDetector = record(
         qtbot,
@@ -61,7 +61,7 @@ def test_recording_spec_frames(qtbot, detectorInfos, numFrames):
 
 
 @pytest.mark.parametrize('detectorInfos',
-                         [detectorInfosBasic, detectorInfosMulti, detectorInfosNonSquare])
+                         [detectorInfosBasic, detectorInfosMulti, detectorInfosNonSquare, detectorInfoXimea])
 def test_recording_spec_time(qtbot, detectorInfos):
     filePerDetector, savedToDiskPerDetector = record(
         qtbot,

--- a/imswitch/imcontrol/model/interfaces/__init__.py
+++ b/imswitch/imcontrol/model/interfaces/__init__.py
@@ -1,5 +1,5 @@
 from .hamamatsu import HamamatsuCamera, HamamatsuCameraMR
 from .hamamatsu_mock import MockHamamatsu
 from .lantzlasers import LantzLaser
-from .ximea import XimeaSettings
+from .ximea_cam import XimeaSettings
 from .ximea_mock import MockXimea, MockImage

--- a/imswitch/imcontrol/model/interfaces/__init__.py
+++ b/imswitch/imcontrol/model/interfaces/__init__.py
@@ -1,3 +1,5 @@
 from .hamamatsu import HamamatsuCamera, HamamatsuCameraMR
 from .hamamatsu_mock import MockHamamatsu
 from .lantzlasers import LantzLaser
+from .ximea import XimeaSettings
+from .ximea_mock import MockXimea, MockImage

--- a/imswitch/imcontrol/model/interfaces/ximea.py
+++ b/imswitch/imcontrol/model/interfaces/ximea.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+from ximea.xidefs import *
+
+@dataclass(frozen=True)
+class XimeaSettings:
+    """Dataclass for Ximea camera parameters.
+    """
+
+    trigger_source = [
+        'XI_TRG_OFF',
+        'XI_TRG_EDGE_RISING',
+        'XI_TRG_EDGE_FALLING',
+        'XI_TRG_LEVEL_HIGH',
+        'XI_TRG_LEVEL_LOW',
+        'XI_TRG_SOFTWARE'
+    ]
+
+    trigger_selector = [
+        "XI_TRG_SEL_FRAME_START",
+        "XI_TRG_SEL_EXPOSURE_ACTIVE",
+        "XI_TRG_SEL_FRAME_BURST_START",
+        "XI_TRG_SEL_FRAME_BURST_ACTIVE",
+        "XI_TRG_SEL_MULTIPLE_EXPOSURES",
+        "XI_TRG_SEL_EXPOSURE_START",
+        "XI_TRG_SEL_MULTI_SLOPE_PHASE_CHANGE",
+        "XI_TRG_SEL_ACQUISITION_START",
+    ]
+
+    gpi_selector = [
+        'XI_GPI_PORT1',
+        'XI_GPI_PORT2',
+        'XI_GPI_PORT3',
+        'XI_GPI_PORT4',
+        'XI_GPI_PORT5',
+        'XI_GPI_PORT6',
+        'XI_GPI_PORT7',
+        'XI_GPI_PORT8',
+        'XI_GPI_PORT9',
+        'XI_GPI_PORT10',
+        'XI_GPI_PORT11',
+        'XI_GPI_PORT12'
+    ]
+
+    gpi_mode = [
+        'XI_GPI_OFF',
+        'XI_GPI_TRIGGER'
+    ]

--- a/imswitch/imcontrol/model/interfaces/ximea.py
+++ b/imswitch/imcontrol/model/interfaces/ximea.py
@@ -1,47 +1,59 @@
-from dataclasses import dataclass
-from ximea.xidefs import *
+from ximea.xiapi import Camera
 
-@dataclass(frozen=True)
 class XimeaSettings:
-    """Dataclass for Ximea camera parameters.
+    """Class for Ximea camera parameters.
+
+    Args
+        camera (Camera): reference to Ximea camera object.
     """
 
-    trigger_source = [
-        'XI_TRG_OFF',
-        'XI_TRG_EDGE_RISING',
-        'XI_TRG_EDGE_FALLING',
-        'XI_TRG_LEVEL_HIGH',
-        'XI_TRG_LEVEL_LOW',
-        'XI_TRG_SOFTWARE'
-    ]
+    def __init__(self, camera: Camera) -> None:
 
-    trigger_selector = [
-        "XI_TRG_SEL_FRAME_START",
-        "XI_TRG_SEL_EXPOSURE_ACTIVE",
-        "XI_TRG_SEL_FRAME_BURST_START",
-        "XI_TRG_SEL_FRAME_BURST_ACTIVE",
-        "XI_TRG_SEL_MULTIPLE_EXPOSURES",
-        "XI_TRG_SEL_EXPOSURE_START",
-        "XI_TRG_SEL_MULTI_SLOPE_PHASE_CHANGE",
-        "XI_TRG_SEL_ACQUISITION_START",
-    ]
+        self.camera = camera
 
-    gpi_selector = [
-        'XI_GPI_PORT1',
-        'XI_GPI_PORT2',
-        'XI_GPI_PORT3',
-        'XI_GPI_PORT4',
-        'XI_GPI_PORT5',
-        'XI_GPI_PORT6',
-        'XI_GPI_PORT7',
-        'XI_GPI_PORT8',
-        'XI_GPI_PORT9',
-        'XI_GPI_PORT10',
-        'XI_GPI_PORT11',
-        'XI_GPI_PORT12'
-    ]
+        self.settings = [
+            { # Trigger source
+                "Off"          : 'XI_TRG_OFF',
+                "Rising edge"  : 'XI_TRG_EDGE_RISING',
+                "Falling edge" : 'XI_TRG_EDGE_FALLING',
+                "High level"   : 'XI_TRG_LEVEL_HIGH',
+                "Low level"    : 'XI_TRG_LEVEL_LOW',
+                "Software"     : 'XI_TRG_SOFTWARE'
+            },
+            { # Trigger type
+                "Acquisition start"        : "XI_TRG_SEL_ACQUISITION_START",
+                "Frame start"              : "XI_TRG_SEL_FRAME_START",
+                "Exposure active"          : "XI_TRG_SEL_EXPOSURE_ACTIVE",
+                "Frame burst start"        : "XI_TRG_SEL_FRAME_BURST_START",
+                "Frame burst active"       : "XI_TRG_SEL_FRAME_BURST_ACTIVE",
+                "Multiple exposures"       : "XI_TRG_SEL_MULTIPLE_EXPOSURES",
+                "Exposure start"           : "XI_TRG_SEL_EXPOSURE_START",
+                "Multi slope phase change" : "XI_TRG_SEL_MULTI_SLOPE_PHASE_CHANGE"
+            },
+            { # GPI
+                "GPI1"  : 'XI_GPI_PORT1',
+                "GPI2"  : 'XI_GPI_PORT2',
+                "GPI3"  : 'XI_GPI_PORT3',
+                "GPI4"  : 'XI_GPI_PORT4',
+                "GPI5"  : 'XI_GPI_PORT5',
+                "GPI6"  : 'XI_GPI_PORT6',
+                "GPI7"  : 'XI_GPI_PORT7',
+                "GPI8"  : 'XI_GPI_PORT8',
+                "GPI9"  : 'XI_GPI_PORT9',
+                "GPI10" : 'XI_GPI_PORT10',
+                "GPI11" : 'XI_GPI_PORT11',
+                "GPI12" : 'XI_GPI_PORT12'
+            },
+            { # GPI mode (current selected GPI)
+                "Off"     : "XI_GPI_OFF",
+                "Trigger" : "XI_GPI_TRIGGER"
+            }
+        ]
 
-    gpi_mode = [
-        'XI_GPI_OFF',
-        'XI_GPI_TRIGGER'
-    ]
+        self.set_parameter = {
+            "Exposure"       : self.camera.set_exposure_direct,
+            "Trigger source" : self.camera.set_trigger_source,
+            "Trigger type"   : self.camera.set_trigger_selector,
+            "GPI"            : self.camera.set_gpi_selector,
+            "GPI mode"       : self.camera.set_gpi_mode
+        }

--- a/imswitch/imcontrol/model/interfaces/ximea.py
+++ b/imswitch/imcontrol/model/interfaces/ximea.py
@@ -1,4 +1,7 @@
-from ximea.xiapi import Camera
+try:
+    from ximea.xiapi import Camera
+except:
+    from ximea_mock import MockXimea as Camera
 
 class XimeaSettings:
     """Class for Ximea camera parameters.

--- a/imswitch/imcontrol/model/interfaces/ximea_cam.py
+++ b/imswitch/imcontrol/model/interfaces/ximea_cam.py
@@ -1,7 +1,7 @@
 try:
     from ximea.xiapi import Camera
-except:
-    from ximea_mock import MockXimea as Camera
+except ModuleNotFoundError:
+    from .ximea_mock import MockXimea as Camera
 
 class XimeaSettings:
     """Class for Ximea camera parameters.

--- a/imswitch/imcontrol/model/interfaces/ximea_mock.py
+++ b/imswitch/imcontrol/model/interfaces/ximea_mock.py
@@ -7,13 +7,13 @@ class MockXimea:
     """Mock Ximea camera
     """
     
-    def __init__(self, camera_id) -> None:
+    def __init__(self) -> None:
         self.__logger = initLogger(self, tryInheritParent=True)
         self._device_info = {
             "device_name" : "MockXimea",
             "device_type" : "Ximea camera mock object"
         }
-        self._device_id = camera_id
+        self._device_id = "Mock Ximea camera"
         self._exposure = 0
         self._width = 1280
         self._height = 864

--- a/imswitch/imcontrol/model/interfaces/ximea_mock.py
+++ b/imswitch/imcontrol/model/interfaces/ximea_mock.py
@@ -10,10 +10,10 @@ class MockXimea:
     def __init__(self) -> None:
         self.__logger = initLogger(self, tryInheritParent=True)
         self._device_info = {
-            "device_name" : "MockXimea",
-            "device_type" : "Ximea camera mock object"
+            "device_name" : b"MockXimea",
+            "device_type" : b"Ximea camera mock object"
         }
-        self._device_id = "Mock Ximea camera"
+        self._device_id = b"Mock Ximea camera"
         self._exposure = 0
         self._width = 1280
         self._height = 864

--- a/imswitch/imcontrol/model/interfaces/ximea_mock.py
+++ b/imswitch/imcontrol/model/interfaces/ximea_mock.py
@@ -24,6 +24,11 @@ class MockXimea:
         self._mock_acquisition_running = False
         self._mock_start_time = time.time_ns()
 
+        self._trig_source = "Off"
+        self._trig_type = "Acquisition start"
+        self._gpi_select = "GPI1"
+        self._gpi_mode = "Off"
+
     def open_device(self):
         self.__logger.info("Mock object opened")
     
@@ -42,6 +47,22 @@ class MockXimea:
 
     def set_exposure(self, exposure):
         self._exposure = exposure
+    
+    def set_exposure_direct(self, exposure):
+        self.set_exposure(exposure)
+
+    def set_trigger_source(self, source):
+        self._trig_source = source
+    
+    def set_trigger_selector(self, selector):
+        self._trig_type = selector
+
+    def set_gpi_selector(self, selector):
+        self._gpi_select = selector
+
+    def set_gpi_mode(self, mode):
+        self._gpi_mode = mode
+
     
     def get_image(self, image):
         # todo: does this work?

--- a/imswitch/imcontrol/model/interfaces/ximea_mock.py
+++ b/imswitch/imcontrol/model/interfaces/ximea_mock.py
@@ -1,0 +1,105 @@
+from dataclasses import dataclass
+import numpy as np
+import time
+from imswitch.imcommon.model.logging import initLogger
+
+class MockXimea:
+    """Mock Ximea camera
+    """
+    
+    def __init__(self, camera_id) -> None:
+        self.__logger = initLogger(self, tryInheritParent=True)
+        self._device_info = {
+            "device_name" : "MockXimea",
+            "device_type" : "Ximea camera mock object"
+        }
+        self._device_id = camera_id
+        self._exposure = 0
+        self._width = 1280
+        self._height = 864
+        self._ofs_x = 0
+        self._ofs_y = 0
+
+        self._mock_data_max_value = (2**10)-1
+        self._mock_acquisition_running = False
+        self._mock_start_time = time.time_ns()
+
+    def open_device(self):
+        self.__logger.info("Mock object opened")
+    
+    def close_device(self):
+        self.__logger.info("Mock object closed")
+    
+    def set_param(self, param, value):
+        # todo: implement ... ?
+        pass
+    
+    def get_device_info_string(self, info):
+        return self._device_info[info]
+
+    def get_device_model_id(self):
+        return "Mock Ximea camera"
+
+    def set_exposure(self, exposure):
+        self._exposure = exposure
+    
+    def get_image(self, image):
+        # todo: does this work?
+        image = MockImage(self._width - self._ofs_x
+                        , self._height - self._ofs_y
+                        , self._mock_data_max_value)
+
+    def start_acquisition(self):
+        self._mock_acquisition_running = True
+
+    def stop_acquisition(self):
+        self._mock_acquisition_running = False
+
+    def get_width_maximum(self):
+        return 1280
+
+    def get_height_maximum(self):
+        return 864
+
+    def set_offsetX(self, ofs_x):
+        self._ofs_x = ofs_x
+
+    def set_offsetY(self, ofs_y):
+        self._ofs_x = ofs_y
+
+    def set_width(self, width):
+        self._width = width
+
+    def set_height(self, height):
+        self._height = height
+    
+    def get_width(self):
+        return self._width
+    
+    def get_height(self):
+        return self._height
+
+@dataclass
+class MockImage:
+    width   : int = 1280
+    height  : int = 864
+    max_val : int = (2**10)-1
+
+    def get_image_data_numpy(self):
+        return np.random.randint(0, self.max_val, (self.height, self.width), np.uint16)
+
+# Copyright (C) 2021 Eggeling Group
+# This file is part of ImSwitch.
+#
+# ImSwitch is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ImSwitch is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/imswitch/imcontrol/model/managers/PulseStreamerManager.py
+++ b/imswitch/imcontrol/model/managers/PulseStreamerManager.py
@@ -7,7 +7,6 @@ import io
 DIG_CH_MAX_NUMBER = 8
 ANG_CH_MAX_NUMBER = 2
 
-
 class PulseStreamerManager(SignalInterface):
     """ For interaction with Pulse Streamer 8/2 from Swabian Instruments. """
 
@@ -34,7 +33,7 @@ class PulseStreamerManager(SignalInterface):
             self.__pulseStreamer = PulseStreamer(self.__ipAddress)
             msg = self.__stdOut.getvalue()
             msg = msg.split("\n")
-            [self.__logger.info(m) for m in msg if len(m) > 1]
+            (self.__logger.info(m) for m in msg if len(m) > 1)
         except:
             # todo: fill exception
             pass       
@@ -43,7 +42,7 @@ class PulseStreamerManager(SignalInterface):
         """Function to set a digital channel output level.
 
         Args:
-            channel (int, list): channel/list of channels to set.
+            channel (int): channel to set.
             enable (int, bool): 0/False to disable output, 1/True to enable output.
         """
         if channel is None:
@@ -52,10 +51,7 @@ class PulseStreamerManager(SignalInterface):
             raise PulseStreamerManagerError(f'Target digital channels are out of bounds (min. is 0, max. is {DIG_CH_MAX_NUMBER-1})')
         else:
             if bool(enable):
-                if isinstance(channel, list):
-                    self.__digitalChannels = channel
-                else:
-                    self.__digitalChannels = [channel]
+                self.__digitalChannels = [channel]
             else:
                 self.__digitalChannels = []
         
@@ -63,7 +59,7 @@ class PulseStreamerManager(SignalInterface):
                                                 self.__analogChannels[0], 
                                                 self.__analogChannels[1]))
 
-    def setAnalog(self, channel, voltage, min_val=-1.0, max_val=1.0):
+    def setAnalog(self, channel, voltage, min_val=0.0, max_val=1.0):
         """Function to set an analog channel output level
 
         Args:
@@ -82,20 +78,10 @@ class PulseStreamerManager(SignalInterface):
             else:
                 voltage = max(voltage, min_val)
 
-            # todo: verbose checks, can we make them more elegant?
-            if isinstance(channel, list):
-                if len(channel) < 2:
-                    if channel[0] == 0:
-                        self.__analogChannels[0] = voltage
-                    else:
-                        self.__analogChannels[1] = voltage
-                else:
-                    self.__analogChannels[0] = self.__analogChannels[1] = voltage
+            if channel == 0:
+                self.__analogChannels[0] = voltage
             else:
-                if channel == 0:
-                    self.__analogChannels[0] = voltage
-                else:
-                    self.__analogChannels[1] = voltage
+                self.__analogChannels[1] = voltage
             self.__pulseStreamer.constant(OutputState(self.__digitalChannels, 
                                                 self.__analogChannels[0], 
                                                 self.__analogChannels[1]))
@@ -104,22 +90,16 @@ class PulseStreamerManager(SignalInterface):
         """Checks the validity of the selected channel (or channels)
 
         Args:
-            channel (int, list): channel/list of channels to verify
+            channel (int): channel to verify
             upper_bound (int): upper limit for channel check
 
         Returns:
             bool: True if channels are OK, else False
         """
-        if isinstance(channel, list):
-            if all(ch >= upper_bound for ch in channel):
-                return False
-            else:
-                return True
+        if channel >= upper_bound:
+            return False
         else:
-            if channel >= upper_bound:
-                return False
-            else:
-                return True
+            return True
             
 
 class PulseStreamerManagerError(Exception):

--- a/imswitch/imcontrol/model/managers/detectors/XimeaManager.py
+++ b/imswitch/imcontrol/model/managers/detectors/XimeaManager.py
@@ -132,7 +132,7 @@ class XimeaManager(DetectorManager):
 
         try:
             
-            self.__logger.info(f"Setting {name} to {ximea_value} us")
+            self.__logger.info(f"Setting {name} to {ximea_value}")
             self._settings.set_parameter[name](ximea_value)
             # update local parameters
             super().setParameter(name, value)

--- a/imswitch/imcontrol/model/managers/detectors/XimeaManager.py
+++ b/imswitch/imcontrol/model/managers/detectors/XimeaManager.py
@@ -3,7 +3,6 @@ from imswitch.imcontrol.model.interfaces import XimeaSettings
 from imswitch.imcommon.model import initLogger
 from collections import deque
 
-from imswitch.imcontrol.model.interfaces import ximea
 from .DetectorManager import (
     DetectorManager, DetectorNumberParameter, DetectorListParameter
 )
@@ -41,8 +40,6 @@ class XimeaManager(DetectorManager):
                      self._camera.get_height_maximum())
 
         model = self._camera.get_device_info_string("device_name").decode("utf-8")
-
-        parameter_list = list(self._settings.set_parameter.keys())
 
         # Prepare parameters
         parameters = {

--- a/imswitch/imcontrol/model/managers/detectors/XimeaManager.py
+++ b/imswitch/imcontrol/model/managers/detectors/XimeaManager.py
@@ -1,0 +1,176 @@
+import numpy as np
+from ximea import xiapi
+from imswitch.imcommon.model import initLogger
+from collections import deque
+from .DetectorManager import (
+    DetectorManager, DetectorNumberParameter, DetectorListParameter
+)
+
+class XimeaManager(DetectorManager):
+    """ DetectorManager that deals with the Ximea parameters and frame
+    extraction for a Ximea camera.
+
+    Manager properties:
+
+    - ``cameraListIndex`` -- the camera's index in the Ximea camera list
+      (list indexing starts at 0); set this to an invalid value, e.g. the
+      string "mock" to load a mocker
+    - ``ximea`` -- dictionary of DCAM API properties to pass to the driver
+    """
+
+    def __init__(self, detectorInfo, name, **_lowLevelManagers):
+        self.__logger = initLogger(self, instanceName=name)
+        self._camera, self._img, settings = self._getCameraObj(detectorInfo.managerProperties['cameraListIndex'])
+
+        # todo: local circular buffer used as a temporary workaround for getChunk
+        # we should investigate if this is the proper way to store images
+        # or another solution is feasible
+        self._frame_buffer = deque([], maxlen=1000)
+
+        # to set Ximea parameters, camera must be open first
+        self._camera.open_device()
+
+        for propertyName, propertyValue in detectorInfo.managerProperties['ximea'].items():
+            self._camera.set_param(propertyName, propertyValue)
+
+        fullShape = (self._camera.get_width_maximum(),
+                     self._camera.get_height_maximum())
+
+        model = self._camera.get_device_model_id()
+
+        # Prepare parameters
+        parameters = {
+            'Exposure': DetectorNumberParameter(group='Timings', value=100,
+                                                         valueUnits='µs', editable=True),
+
+            'Trigger source': DetectorListParameter(group='Trigger settings',
+                                                    value=settings.trigger_source[0],
+                                                    options=settings.trigger_source,
+                                                    editable=True),
+            
+            'Trigger selector': DetectorListParameter(group='Trigger settings',
+                                                value=settings.trigger_selector[0],
+                                                options=settings.trigger_selector,
+                                                editable=True),
+
+            'GPI mode': DetectorListParameter(group='Trigger settings',
+                                            value=settings.gpi_mode[0],
+                                            options=settings.gpi_mode,
+                                            editable=True),
+
+            'GPI selector': DetectorListParameter(group='Acquisition mode',
+                                                    value=settings.gpi_selector[0],
+                                                    options=settings.gpi_selector,
+                                                    editable=True),
+            
+            'Camera pixel size': DetectorNumberParameter(group='Miscellaneous', value=13.7,
+                                                         valueUnits='µm', editable=False),                                                        
+        }
+
+        super().__init__(detectorInfo, name, fullShape=fullShape, supportedBinnings=[1],
+                         model=model, parameters=parameters, croppable=True)
+    
+    @property
+    def pixelSizeUm(self):
+        umxpx = self.parameters['Camera pixel size'].value
+        return [1, umxpx, umxpx]
+
+    def getLatestFrame(self):
+        self._camera.get_image(self._img)
+        data = self._img.get_image_data_numpy()
+        self._frame_buffer.append(data)
+        return data
+
+    def getChunk(self):
+        return np.stack(self._frame_buffer)
+
+    def flushBuffers(self):
+        self._frame_buffer.clear()
+
+    def crop(self, hpos, vpos, hsize, vsize):
+        """Method to crop the frame read out by the camera. """
+
+        def cropAction():
+            self._camera.set_offsetX(0)
+            self._camera.set_offsetY(0)
+            self._camera.set_width(self.fullShape[1])
+            self._camera.set_height(self.fullShape[0])
+
+            if (hsize, vsize) != self.fullShape:
+                self._camera.set_offsetX(vpos)
+                self._camera.set_offsetY(hpos)
+                self._camera.set_width(vsize)
+                self._camera.set_height(hsize)
+
+        self._performSafeCameraAction(cropAction)
+
+        # This should be the only place where self.frameStart is changed
+        self._frameStart = (hpos, vpos)
+        # Only place self.shapes is changed
+        self._shape = (hsize, vsize)
+
+    def setBinning(self, binning):
+        # todo: Ximea binning works in a different way
+        # investigate how to properly update this value
+        super().setBinning(binning)
+
+    def setParameter(self, name : str, value):
+        # Ximea parameters should follow the naming convention
+        # described in https://www.ximea.com/support/wiki/apis/XiAPI_Manual
+
+        # parameter names are lower case
+        # for multiple words, join them with '_' character
+        name = "_".join(name.lower().split(" "))
+
+        # call set_param from Ximea camera
+        self._camera.set_param(name, value)
+
+        # then update local parameters
+        super().setParameter(name, value)
+
+        return self.parameters
+
+    def startAcquisition(self):
+        self._camera.start_acquisition()
+
+    def stopAcquisition(self):
+        self._camera.stop_acquisition()
+    
+    def finalize(self) -> None:
+        self._camera.close_device()
+
+    def _setExposure(self, time):
+        self._camera.set_exposure(time)
+
+    def _performSafeCameraAction(self, function):
+        """ This method is used to change those camera properties that need
+        the camera to be idle to be able to be adjusted.
+        """
+        try:
+            function()
+        except Exception:
+            self.stopAcquisition()
+            function()
+            self.startAcquisition()
+
+    def _getCameraObj(self, cameraId):
+        
+        from imswitch.imcontrol.model.interfaces import XimeaSettings
+        camera_settings = XimeaSettings()
+
+        try:
+            from ximea.xiapi import Camera, Image
+            self.__logger.debug(f'Trying to initialize Ximea camera {cameraId}')
+            camera = Camera(cameraId)
+            image = Image()
+            camera_name = camera.get_device_info_string("device_name") + ": " + camera.get_device_info_string("device_type")
+        except:
+            self.__logger.warning(f'Failed to initialize Ximea camera {cameraId},'
+                                  f' loading mocker')
+            from imswitch.imcontrol.model.interfaces import MockXimea, MockImage
+            camera = MockXimea()
+            image = MockImage()
+            camera_name = camera.get_device_info_string("device_name") + ": " + camera.get_device_info_string("device_type")
+
+        self.__logger.info(f'Initialized camera, model: {camera_name}')
+        return camera, image, camera_settings


### PR DESCRIPTION
I've been currently working on integrating the Ximea XIAPI into ImSwitch to handle their cameras.

At the moment the XimeaManager can control the following settings

- Exposure time
- Trigger selection
- GPI (General Purpose Input) as trigger channel

There are much more features which can/should be implemented, but this is a starting point.

The manager also provides a mock method for the Ximea camera in case an user doesn't have the APIs installed, in a similar fashion in which the Hamamatsu mock object works.

A couple of notes/possible problems:
- testing: with my previous experience in regards to failed builds, I would like to integrate testing for the Ximea but I could use some hints on where to begin on that;
- weird exposure behaviour: when using the live view with the Ximea, the images appear to be much more luminous in comparison to when snapping a single image. I don't think it's an ImSwitch error, but rather an incorrect behaviour of the manager but I'm not entirely sure why and where to look at it;
- `getChunk` method: as far as I've understood, the Ximea does not behave as the Hamamatsu in terms of frame buffer, meaning that you can only get the latest image from the camera hardware buffer. To circumvent this, I've implemented a local frame buffer (line 35 of `XimeaManager.py`) which stores 1000 frames, and with `numpy.stack` creates a single stack. It may be possible to actually get the frame buffer from the Ximea camera, but it's only speculation and I'll investigate more the XiAPI documentation.

Let me know what you think of it, some feedback would be greatly appreciated!