### PR TITLE
Laser GUI update for frequency modulation

### DIFF
--- a/imswitch/imcontrol/controller/controllers/LaserController.py
+++ b/imswitch/imcontrol/controller/controllers/LaserController.py
@@ -20,7 +20,8 @@ class LaserController(ImConWidgetController):
             self._widget.addLaser(
                 lName, lManager.valueUnits, lManager.valueDecimals, lManager.wavelength,
                 (lManager.valueRangeMin, lManager.valueRangeMax) if not lManager.isBinary else None,
-                lManager.valueRangeStep if lManager.valueRangeStep is not None else None
+                lManager.valueRangeStep if lManager.valueRangeStep is not None else None,
+                (lManager.freqRangeMin, lManager.freqRangeMax, lManager.freqRangeInit) if lManager.isModulated else None
             )
             if not lManager.isBinary:
                 self.valueChanged(lName, lManager.valueRangeMin)
@@ -66,6 +67,10 @@ class LaserController(ImConWidgetController):
         self._master.lasersManager[laserName].setValue(magnitude)
         self._widget.setValue(laserName, magnitude)
         self.setSharedAttr(laserName, _valueAttr, magnitude)
+    
+    def frequencyChanged(self, laserName, frequency):
+        """ Change modulation frequency. """
+        self._master.lasersManager[laserName].setModulationFrequency(frequency)
 
     def presetSelected(self, presetName):
         """ Handles what happens when a preset is selected in the preset list.

--- a/imswitch/imcontrol/controller/controllers/LaserController.py
+++ b/imswitch/imcontrol/controller/controllers/LaserController.py
@@ -46,6 +46,10 @@ class LaserController(ImConWidgetController):
         self._widget.sigEnableChanged.connect(self.toggleLaser)
         self._widget.sigValueChanged.connect(self.valueChanged)
 
+        self._widget.sigModEnabledChanged.connect(self.toggleModulation)
+        self._widget.sigFreqChanged.connect(self.frequencyChanged)
+        self._widget.sigDutyCycleChanged.connect(self.dutyCycleChanged)
+
         self._widget.sigPresetSelected.connect(self.presetSelected)
         self._widget.sigLoadPresetClicked.connect(self.loadPreset)
         self._widget.sigSavePresetClicked.connect(self.savePreset)
@@ -68,9 +72,22 @@ class LaserController(ImConWidgetController):
         self._widget.setValue(laserName, magnitude)
         self.setSharedAttr(laserName, _valueAttr, magnitude)
     
+    def toggleModulation(self, laserName, enabled):
+        """ Enable or disable laser modulation (on/off). """
+        self._master.lasersManager[laserName].setModulationEnabled(enabled)
+        self.setSharedAttr(laserName, _freqEnAttr, enabled)
+
     def frequencyChanged(self, laserName, frequency):
         """ Change modulation frequency. """
         self._master.lasersManager[laserName].setModulationFrequency(frequency)
+        self._widget.setModulationFrequency(laserName, frequency)
+        self.setSharedAttr(laserName, _freqAttr, frequency)
+    
+    def dutyCycleChanged(self, laserName, dutyCycle):
+        """ Change modulation duty cycle. """
+        self._master.lasersManager[laserName].setModulationDutyCycle(dutyCycle)
+        self._widget.setModulationDutyCycle(laserName, dutyCycle)
+        self.setSharedAttr(laserName, _dcAttr, dutyCycle)
 
     def presetSelected(self, presetName):
         """ Handles what happens when a preset is selected in the preset list.
@@ -252,6 +269,9 @@ class LaserController(ImConWidgetController):
 _attrCategory = 'Laser'
 _enabledAttr = 'Enabled'
 _valueAttr = 'Value'
+_freqEnAttr = "ModulationEnabled"
+_freqAttr = "Frequency"
+_dcAttr = "DutyCycle"
 
 
 # Copyright (C) 2020-2021 ImSwitch developers

--- a/imswitch/imcontrol/controller/controllers/LaserController.py
+++ b/imswitch/imcontrol/controller/controllers/LaserController.py
@@ -21,7 +21,7 @@ class LaserController(ImConWidgetController):
                 lName, lManager.valueUnits, lManager.valueDecimals, lManager.wavelength,
                 (lManager.valueRangeMin, lManager.valueRangeMax) if not lManager.isBinary else None,
                 lManager.valueRangeStep if lManager.valueRangeStep is not None else None,
-                (lManager.freqRangeMin, lManager.freqRangeMax, lManager.freqRangeInit) if lManager.isModulated else None
+                (lManager.freqRangeMin, lManager.freqRangeMax, lManager.freqRangeInit) if lManager.isModulated else (0, 0, 0)
             )
             if not lManager.isBinary:
                 self.valueChanged(lName, lManager.valueRangeMin)

--- a/imswitch/imcontrol/model/SetupInfo.py
+++ b/imswitch/imcontrol/model/SetupInfo.py
@@ -56,17 +56,17 @@ class LaserInfo(DeviceInfo):
     """ maximum value of the laser. ``null`` if laser doesn't setting a value.
     """
 
-    freqRangeMin: Optional[int]
-    """ Minimum value of frequency modulation. ``null`` if laser doesn't support it. """
-
-    freqRangeMax: Optional[int]
-    """ Minimum value of frequency modulation. ``null`` if laser doesn't support it. """
-
-    freqRangeInit: Optional[int]
-    """ Initial value of frequency modulation. ``null`` if laser doesn't support it. """
-
     wavelength: Union[int, float]
     """ Laser wavelength in nanometres. """
+
+    freqRangeMin: Optional[int] = 0
+    """ Minimum value of frequency modulation. Don't fill if laser doesn't support it. """
+
+    freqRangeMax: Optional[int] = 0
+    """ Minimum value of frequency modulation. Don't fill if laser doesn't support it. """
+
+    freqRangeInit: Optional[int] = 0
+    """ Initial value of frequency modulation. Don't fill if laser doesn't support it. """
 
     valueRangeStep: float = 1.0
     """ The default step size of the value range that the laser can be set to.

--- a/imswitch/imcontrol/model/SetupInfo.py
+++ b/imswitch/imcontrol/model/SetupInfo.py
@@ -56,12 +56,22 @@ class LaserInfo(DeviceInfo):
     """ maximum value of the laser. ``null`` if laser doesn't setting a value.
     """
 
+    freqRangeMin: Optional[int]
+    """ Minimum value of frequency modulation. ``null`` if laser doesn't support it. """
+
+    freqRangeMax: Optional[int]
+    """ Minimum value of frequency modulation. ``null`` if laser doesn't support it. """
+
+    freqRangeInit: Optional[int]
+    """ Initial value of frequency modulation. ``null`` if laser doesn't support it. """
+
     wavelength: Union[int, float]
     """ Laser wavelength in nanometres. """
 
     valueRangeStep: float = 1.0
     """ The default step size of the value range that the laser can be set to.
     """
+
 
 
 @dataclass(frozen=True)

--- a/imswitch/imcontrol/model/managers/lasers/CoolLEDLaserManager.py
+++ b/imswitch/imcontrol/model/managers/lasers/CoolLEDLaserManager.py
@@ -22,7 +22,12 @@ class CoolLEDLaserManager(LaserManager):
         self.__channel_index = laserInfo.managerProperties['channel_index']
         self.__digital_mod = False
 
-        super().__init__(laserInfo, name, isBinary=False, valueUnits='mW', valueDecimals=0)
+        isModulated = (True if laserInfo.freqRangeMin != None and 
+                                laserInfo.freqRangeMax != None and
+                                laserInfo.freqRangeInit != None 
+                            else False)
+
+        super().__init__(laserInfo, name, isBinary=False, valueUnits='mW', valueDecimals=0, isModulated=isModulated)
 
     def setEnabled(self, enabled):
         """Turn on (N) or off (F) laser emission"""

--- a/imswitch/imcontrol/model/managers/lasers/LaserManager.py
+++ b/imswitch/imcontrol/model/managers/lasers/LaserManager.py
@@ -9,7 +9,7 @@ class LaserManager(ABC):
 
     @abstractmethod
     def __init__(self, laserInfo, name: str, isBinary: bool, valueUnits: str,
-                 valueDecimals: int) -> None:
+                 valueDecimals: int, isModulated: bool = False) -> None:
         """
         Args:
             laserInfo: See setup file documentation.
@@ -19,6 +19,7 @@ class LaserManager(ABC):
               value cannot be changed.
             valueUnits: The units of the laser value, e.g. "mW" or "V".
             valueDecimals: How many decimals are accepted in the laser value.
+            isModulated: Whether the laser can be frequency modulated.
         """
         self._laserInfo = laserInfo
         self.__name = name
@@ -29,6 +30,15 @@ class LaserManager(ABC):
         self.__valueRangeStep = laserInfo.valueRangeStep
         self.__valueUnits = valueUnits
         self.__valueDecimals = valueDecimals
+        self.__isModulated = isModulated
+        if isModulated:
+            self.__freqRangeMin = laserInfo.freqRangeMin
+            self.__freqRangeMax = laserInfo.freqRangeMax
+            self.__freqRangeInit = laserInfo.freqRangeInit
+        else:
+            self.__freqRangeMin = None
+            self.__freqRangeMax = None
+            self.__freqRangeInit = None
 
     @property
     def name(self) -> str:
@@ -71,6 +81,26 @@ class LaserManager(ABC):
     def valueDecimals(self):
         """ How many decimals are accepted in the laser value. """
         return self.__valueDecimals
+    
+    @property
+    def isModulated(self) -> bool:
+        """ Whether the laser supports frequency modulation."""
+        return self.__isModulated
+
+    @property
+    def freqRangeMin(self) -> int:
+        """ The minimum frequency of the laser modulation. """
+        return self.__freqRangeMin
+    
+    @property
+    def freqRangeMax(self) -> int:
+        """ The minimum frequency of the laser modulation. """
+        return self.__freqRangeMax
+    
+    @property
+    def freqRangeInit(self) -> int:
+        """ The initial frequency of the laser modulation. """
+        return self.__freqRangeInit
 
     @abstractmethod
     def setEnabled(self, enabled: bool) -> None:
@@ -81,6 +111,17 @@ class LaserManager(ABC):
     def setValue(self, value: Union[int, float]) -> None:
         """ Sets the value of the laser. """
         pass
+
+    def setModulationEnabled(self, enabled: bool) -> None:
+        """ Sets wether the laser frequency modulation is enabled. """
+        pass
+
+    def setModulationFrequency(self, frequency: int) -> None:
+        """ Sets the laser modulation frequency. """
+        pass
+    
+    def setModulationDutyCycle(self, dutyCycle: int) -> None:
+        """ Sets the laser modulation duty cycle. """
 
     def setScanModeActive(self, active: bool) -> None:
         """ Sets whether the laser should be in scan mode (if the laser

--- a/imswitch/imcontrol/view/widgets/LaserWidget.py
+++ b/imswitch/imcontrol/view/widgets/LaserWidget.py
@@ -11,9 +11,9 @@ class LaserWidget(Widget):
     sigEnableChanged = QtCore.Signal(str, bool)  # (laserName, enabled)
     sigValueChanged = QtCore.Signal(str, float)  # (laserName, value)
     
-    sigModEnabledChanged = QtCore.Signal(str, bool) # (laserName, modulation enabled)
+    sigModEnabledChanged = QtCore.Signal(str, bool) # (laserName, modulationEnabled)
     sigFreqChanged = QtCore.Signal(str, int)        # (laserName, frequency)
-    sigDutyCycleChanged = QtCore.Signal(str, int)   # (laserName, duty cycle)
+    sigDutyCycleChanged = QtCore.Signal(str, int)   # (laserName, dutyCycle)
 
     sigPresetSelected = QtCore.Signal(str)  # (presetName)
     sigLoadPresetClicked = QtCore.Signal()
@@ -104,6 +104,9 @@ class LaserWidget(Widget):
         )
 
         if frequencyRange is not None:
+            control.sigModEnabledChanged.connect(
+                lambda enabled: self.sigModEnabledChanged.emit(laserName, enabled)
+            )
             control.sigFreqChanged.connect(
                 lambda frequency: self.sigFreqChanged.emit(laserName, frequency)
             )
@@ -153,6 +156,14 @@ class LaserWidget(Widget):
         """ Sets the value of the specified laser, in the units that the laser
         uses. """
         self.laserModules[laserName].setValue(value)
+    
+    def setModulationFrequency(self, laserName, value):
+        """ Sets the modulation frequency of the specified laser. """
+        self.laserModules[laserName].setModulationFrequency(value)
+
+    def setModulationDutyCycle(self, laserName, value):
+        """ Sets the modulation duty cycle of the specified laser. """
+        self.laserModules[laserName].setModulationDutyCycle(value)
 
     def getCurrentPreset(self):
         """ Returns the name of the currently selected preset. """
@@ -405,6 +416,16 @@ class LaserModule(QtWidgets.QWidget):
         """ Sets the value of the laser, in the units that the laser uses. """
         self.setPointEdit.setText(f'%.{self.valueDecimals}f' % value)
         self.slider.setValue(value)
+    
+    def setModulationFrequency(self, value):
+        """ Sets the laser modulation frequency. """
+        self.modulationFrequencyEdit.setText(f"{value}")
+        self.modulationFrequencySlider.setValue(value)
+    
+    def setModulationDutyCycle(self, value):
+        """ Sets the laser modulation duty cycle. """
+        self.modulationDutyCycleEdit.setText(f"{value}")
+        self.modulationDutyCycleSlider.setValue(value)
 
 
 # Copyright (C) 2017 Federico Barabas 2020-2021 ImSwitch developers

--- a/imswitch/imcontrol/view/widgets/LaserWidget.py
+++ b/imswitch/imcontrol/view/widgets/LaserWidget.py
@@ -84,11 +84,11 @@ class LaserWidget(Widget):
         self.layout.addLayout(self.presetsBox, 1, 0)
 
     def addLaser(self, laserName, valueUnits, valueDecimals, wavelength, valueRange=None,
-                 valueRangeStep=1, frequencyRange=None):
+                 valueRangeStep=1, frequencyRange=(0, 0, 0)):
         """ Adds a laser module widget. valueRange is either a tuple
         (min, max), or None (if the laser can only be turned on/off).
         frequencyRange is either a tuple (min, max, initVal)
-        or None (if the laser is not modulated in frequency)"""
+        or (0, 0, 0) (if the laser is not modulated in frequency)"""
 
         control = LaserModule(
             valueUnits=valueUnits, valueDecimals=valueDecimals, valueRange=valueRange,
@@ -103,7 +103,7 @@ class LaserWidget(Widget):
             lambda value: self.sigValueChanged.emit(laserName, value)
         )
 
-        if frequencyRange is not None:
+        if all(num > 0 for num in frequencyRange):
             control.sigModEnabledChanged.connect(
                 lambda enabled: self.sigModEnabledChanged.emit(laserName, enabled)
             )
@@ -243,7 +243,7 @@ class LaserModule(QtWidgets.QWidget):
         self.valueDecimals = valueDecimals
 
         isBinary = valueRange is None
-        isModulated = frequencyRange is not None
+        isModulated = all(num > 0 for num in frequencyRange)
 
         # Graphical elements
         self.setPointLabel = QtWidgets.QLabel(f'Setpoint [{valueUnits}]')


### PR DESCRIPTION
- Lasers can now support modulation frequency
- Changed laser GUI
- Added all the necessary connection logic in the model

Tested with CoolLEDManager (changes for this Manager are not pushed since they are not relevant). The GUI now looks like this:

![image](https://user-images.githubusercontent.com/20145526/159298711-b6fa8373-c1d0-4ede-b5ef-75f2473cd5e5.png)

Depending on the JSON configuration each laser can be modulated in frequency or not