### PR TITLE
Add smaract hardware

### DIFF
--- a/imswitch/imcontrol/__test_Manager.py
+++ b/imswitch/imcontrol/__test_Manager.py
@@ -1,0 +1,78 @@
+import numpy as np
+
+from imswitch.imcontrol.model import configfiletools
+
+from imswitch.imcontrol.model.managers.positioners.SmarACTPositionerManager import SmarACTPositionerManager
+from unittest import TestCase
+import logging
+
+from imswitch.imcontrol.view import ViewSetupInfo
+
+logger = logging.getLogger('test stage')
+logging.basicConfig(level=logging.DEBUG)
+logger.error('critical1')
+
+class TestReadConfig(TestCase):
+
+    def test_me(self):
+        options, optionsDidNotExist = configfiletools.loadOptions()
+        print(options)
+        setupInfo = configfiletools.loadSetupInfo(options, ViewSetupInfo )
+        print(setupInfo)
+
+class Test_PM(TestCase):
+
+    def setUp(self) -> None:
+        options, optionsDidNotExist = configfiletools.loadOptions()
+        setupInfo = configfiletools.loadSetupInfo(options, ViewSetupInfo)
+        p_info = setupInfo.positioners['SmarACT']
+        self.drive: SmarACTPositionerManager = SmarACTPositionerManager(positionerInfo=p_info, name='something')
+
+    def tearDown(self) -> None:
+        self.drive.finalize()
+
+    def test_connect(self):
+        print('Setting up what the positioners are')
+        print('Drive name: ', self.drive.name)
+
+
+
+    def test_get_position(self):
+        current_position = self.drive.position
+        logger.critical(f'Current position: {current_position}')
+        print(current_position)
+
+    def test_move(self):
+
+        for i, axis in enumerate('XYZ'):
+            print(f'###### {i} #### {axis}')
+            position = self.drive.position
+            position_at_axis = position[axis]
+            direction = -1*np.sign(position_at_axis)
+            self.drive.move(direction, axis)
+            new_position = self.drive.position
+            new_position_at_axis = new_position[axis]
+            position_as_array = np.array([position[a] for a in 'XYZ'])
+            new_position_as_array = np.array([new_position[a] for a in 'XYZ'])
+            diff = new_position_as_array - position_as_array
+
+            msg = f'Error when moving axis {axis}.\n'
+            msg += f'Initial position: {position_as_array}\n, new position: {new_position_as_array}\n, diff: {diff}\n'
+            msg += str(self.drive.position)
+            self.assertLessEqual(diff[i]-direction, 0.1, msg)
+
+            logger.critical(f'Current position {self.drive.position}')
+
+
+    def test_move_to_zero(self):
+        for ax in self.drive.axes:
+            logger.info(f'Moving axis {ax} to 0')
+            self.drive.setPosition(position=0, axis=ax)
+            p_out = self.drive.position
+            try:
+                self.assertAlmostEqual(p_out[ax], 0, places=3)
+            except AssertionError:
+                logger.error(f'Could not move the position properly for axis {ax}. Got: ')
+                logger.info(f'Final position: {self.drive.position}')
+
+

--- a/imswitch/imcontrol/__test_Manager.py
+++ b/imswitch/imcontrol/__test_Manager.py
@@ -14,13 +14,6 @@ logging.basicConfig(level=logging.INFO)
 
 OK_to_run=True
 
-class TestReadConfig(TestCase):
-
-    def test_me(self):
-        options, optionsDidNotExist = configfiletools.loadOptions()
-        print(options)
-        setupInfo = configfiletools.loadSetupInfo(options, ViewSetupInfo )
-        print(setupInfo)
 
 class TestSmarACTPositionManager(TestCase):
 
@@ -39,7 +32,7 @@ class TestSmarACTPositionManager(TestCase):
         options, optionsDidNotExist = configfiletools.loadOptions()
         setupInfo = configfiletools.loadSetupInfo(options, ViewSetupInfo)
         p_info = setupInfo.positioners['SmarACT']
-        self.drive: SmarACTPositionerManager = SmarACTPositionerManager(positionerInfo=p_info, name='something')
+        self.drive: SmarACTPositionerManager = SmarACTPositionerManager(positionerInfo=p_info, name='drive to test')
 
     def tearDown(self) -> None:
         self.drive.finalize()
@@ -54,7 +47,9 @@ class TestSmarACTPositionManager(TestCase):
 
 
     def test_move(self):
-        "Move all axes once and check that the movements are what we expect."
+        """
+        Move all axes once and check that the movements are what we expect.
+        """
         for i, axis in enumerate('XYZ'):
             print(f'###### {i} #### {axis}')
             position = self.drive.position
@@ -72,7 +67,6 @@ class TestSmarACTPositionManager(TestCase):
             msg += str(self.drive.position)
             self.assertLessEqual(diff[i]-direction, 0.1, msg)
 
-            logger.critical(f'Current position {self.drive.position}')
 
 
     def test_move_to_zero(self):

--- a/imswitch/imcontrol/model/interfaces/SmarACT.py
+++ b/imswitch/imcontrol/model/interfaces/SmarACT.py
@@ -1,0 +1,1150 @@
+# /**********************************************************************
+# * Copyright (c) 2006-2017 SmarAct GmbH
+# *
+# * File name: MCSControl_PythonWrapper.py
+# * Author   : Marc Schiffner/ Jan Heye Buss
+# * Version  : 2.0.24
+# *
+# * This is the software interface to the Modular Control System.
+# * Please refer to the Programmer's Guide for a detailed documentation.
+# *
+# * THIS  SOFTWARE, DOCUMENTS, FILES AND INFORMATION ARE PROVIDED 'AS IS'
+# * WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING,
+# * BUT  NOT  LIMITED  TO,  THE  IMPLIED  WARRANTIES  OF MERCHANTABILITY,
+# * FITNESS FOR A PURPOSE, OR THE WARRANTY OF NON-INFRINGEMENT.
+# * THE  ENTIRE  RISK  ARISING OUT OF USE OR PERFORMANCE OF THIS SOFTWARE
+# * REMAINS WITH YOU.
+# * IN  NO  EVENT  SHALL  THE  SMARACT  GMBH  BE  LIABLE  FOR ANY DIRECT,
+# * INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL OR OTHER DAMAGES ARISING
+# * OUT OF THE USE OR INABILITY TO USE THIS SOFTWARE.
+# **********************************************************************/
+
+# Import ctypes from standard python to import c.dll(s)
+import ctypes as ct
+
+#define standard SA_types // not really necessary in Python
+SA_STATUS = ct.c_ulong()
+SA_INDEX  = ct.c_ulong()
+SA_PACKET_TYPE  = ct.c_ulong()
+
+MCS_lib = ct.cdll.LoadLibrary("MCSControl")
+
+# // defines a data packet for the asynchronous mode
+class SA_packet(ct.Structure):
+	_fields_ = [
+    ("SA_PACKET_TYPE", ct.c_ulong),                      #// type of packet (see below)
+    ("SA_INDEX", ct.c_ulong),                          #// source channel
+    ("data1", ct.c_ulong),                             #// data field
+    ("data2", ct.c_long),                               #// data field
+    ("data3",ct.c_long),                               #// data field
+    ("data4", ct.c_ulong)]                             #// data field
+
+
+# function status return values
+SA_OK                               =       0
+SA_INITIALIZATION_ERROR             =       1
+SA_NOT_INITIALIZED_ERROR            =       2
+SA_NO_SYSTEMS_FOUND_ERROR           =       3
+SA_TOO_MANY_SYSTEMS_ERROR           =       4
+SA_INVALID_SYSTEM_INDEX_ERROR       =       5
+SA_INVALID_CHANNEL_INDEX_ERROR      =       6
+SA_TRANSMIT_ERROR                   =       7
+SA_WRITE_ERROR                      =       8
+SA_INVALID_PARAMETER_ERROR          =       9
+SA_READ_ERROR                       =       10
+SA_INTERNAL_ERROR                   =       12
+SA_WRONG_MODE_ERROR                 =       13
+SA_PROTOCOL_ERROR                   =       14
+SA_TIMEOUT_ERROR                    =       15
+SA_ID_LIST_TOO_SMALL_ERROR          =       17
+SA_SYSTEM_ALREADY_ADDED_ERROR       =       18
+SA_WRONG_CHANNEL_TYPE_ERROR         =       19
+SA_CANCELED_ERROR                   =       20
+SA_INVALID_SYSTEM_LOCATOR_ERROR     =       21
+SA_INPUT_BUFFER_OVERFLOW_ERROR      =       22
+SA_QUERYBUFFER_SIZE_ERROR           =       23
+SA_DRIVER_ERROR                     =       24
+SA_NO_SUCH_SLAVE_ERROR              =       128
+SA_NO_SENSOR_PRESENT_ERROR          =       129
+SA_AMPLITUDE_TOO_LOW_ERROR          =       130
+SA_AMPLITUDE_TOO_HIGH_ERROR         =       131
+SA_FREQUENCY_TOO_LOW_ERROR          =       132
+SA_FREQUENCY_TOO_HIGH_ERROR         =       133
+SA_SCAN_TARGET_TOO_HIGH_ERROR       =       135
+SA_SCAN_SPEED_TOO_LOW_ERROR         =       136
+SA_SCAN_SPEED_TOO_HIGH_ERROR        =       137
+SA_SENSOR_DISABLED_ERROR            =       140
+SA_COMMAND_OVERRIDDEN_ERROR         =       141
+SA_END_STOP_REACHED_ERROR           =       142
+SA_WRONG_SENSOR_TYPE_ERROR          =       143
+SA_COULD_NOT_FIND_REF_ERROR         =       144
+SA_WRONG_END_EFFECTOR_TYPE_ERROR    =       145
+SA_MOVEMENT_LOCKED_ERROR            =       146
+SA_RANGE_LIMIT_REACHED_ERROR        =       147
+SA_PHYSICAL_POSITION_UNKNOWN_ERROR  =       148
+SA_OUTPUT_BUFFER_OVERFLOW_ERROR     =       149
+SA_COMMAND_NOT_PROCESSABLE_ERROR    =       150
+SA_WAITING_FOR_TRIGGER_ERROR        =       151
+SA_COMMAND_NOT_TRIGGERABLE_ERROR    =       152
+SA_COMMAND_QUEUE_FULL_ERROR         =       153
+SA_INVALID_COMPONENT_ERROR          =       154
+SA_INVALID_SUB_COMPONENT_ERROR      =       155
+SA_INVALID_PROPERTY_ERROR           =       156
+SA_PERMISSION_DENIED_ERROR          =       157
+SA_CALIBRATION_FAILED_ERROR         =       160
+SA_UNKNOWN_COMMAND_ERROR            =       240
+SA_OTHER_ERROR                      =       255
+
+# general definitions
+SA_UNDEFINED                        =       0
+SA_FALSE                            =       0
+SA_TRUE                             =       1
+SA_DISABLED                         =       0
+SA_ENABLED                          =       1
+SA_FALLING_EDGE                     =       0
+SA_RISING_EDGE                      =       1
+SA_FORWARD                          =       0
+SA_BACKWARD                         =       1
+
+# component selectors
+SA_GENERAL                          =       1
+SA_DIGITAL_IN                       =       2
+SA_ANALOG_IN                        =       3
+SA_COUNTER                          =       4
+SA_CAPTURE_BUFFER                   =       5
+SA_COMMAND_QUEUE                    =       6
+SA_SOFTWARE_TRIGGER                 =       7
+SA_SENSOR                           =       8
+SA_MONITOR                          =       9
+
+# component sub selectors
+SA_EMERGENCY_STOP                   =       1
+SA_LOW_VIBRATION                    =       2
+
+SA_BROADCAST_STOP                   =       4
+SA_POSITION_CONTROL                 =       5
+
+SA_REFERENCE_SIGNAL                 =       7
+
+SA_POWER_SUPPLY                     =       11
+
+SA_SCALE                            =       22
+SA_ANALOG_AUX_SIGNAL                =       23
+
+# component properties
+SA_OPERATION_MODE                   =       1
+SA_ACTIVE_EDGE                      =       2
+SA_TRIGGER_SOURCE                   =       3
+SA_SIZE                             =       4
+SA_VALUE                            =       5
+SA_CAPACITY                         =       6
+SA_DIRECTION                        =       7
+SA_SETPOINT                         =       8
+SA_P_GAIN                           =       9
+SA_P_RIGHT_SHIFT                    =       10
+SA_I_GAIN                           =       11
+SA_I_RIGHT_SHIFT                    =       12
+SA_D_GAIN                           =       13
+SA_D_RIGHT_SHIFT                    =       14
+SA_ANTI_WINDUP                      =       15
+SA_PID_LIMIT                        =       16
+SA_FORCED_SLIP                      =       17
+
+SA_THRESHOLD                        =       38
+SA_DEFAULT_OPERATION_MODE           =       45
+
+SA_OFFSET                           =       47
+SA_DISTANCE_TO_REF_MARK             =       48
+SA_REFERENCE_SPEED                  =       49
+
+# operation mode property values for SA_EMERGENCY_STOP sub selector
+SA_ESM_NORMAL                       =       0
+SA_ESM_RESTRICTED                   =       1
+SA_ESM_DISABLED                     =       2
+SA_ESM_AUTO_RELEASE                 =       3
+
+# configuration flags for SA_InitDevices
+SA_SYNCHRONOUS_COMMUNICATION        =       0
+SA_ASYNCHRONOUS_COMMUNICATION       =       1
+SA_HARDWARE_RESET                   =       2
+
+# return values from SA_GetInitState
+SA_INIT_STATE_NONE                  =       0
+SA_INIT_STATE_SYNC                  =       1
+SA_INIT_STATE_ASYNC                 =       2
+
+# return values for SA_GetChannelType
+SA_POSITIONER_CHANNEL_TYPE          =       0
+SA_END_EFFECTOR_CHANNEL_TYPE        =       1
+
+# Hand Control Module modes for SA_SetHCMEnabled
+SA_HCM_DISABLED                     =       0
+SA_HCM_ENABLED                      =       1
+SA_HCM_CONTROLS_DISABLED            =       2
+
+# configuration values for SA_SetBufferedOutput_A
+SA_UNBUFFERED_OUTPUT                =       0
+SA_BUFFERED_OUTPUT                  =       1
+
+# configuration values for SA_SetStepWhileScan_X
+SA_NO_STEP_WHILE_SCAN               =       0
+SA_STEP_WHILE_SCAN                  =       1
+
+# configuration values for SA_SetAccumulateRelativePositions_X
+SA_NO_ACCUMULATE_RELATIVE_POSITIONS =       0
+SA_ACCUMULATE_RELATIVE_POSITIONS    =       1
+
+# configuration values for SA_SetSensorEnabled_X
+SA_SENSOR_DISABLED                  =       0
+SA_SENSOR_ENABLED                   =       1
+SA_SENSOR_POWERSAVE                 =       2
+
+# movement directions for SA_FindReferenceMark_X
+SA_FORWARD_DIRECTION                     		= 0
+SA_BACKWARD_DIRECTION                    		= 1
+SA_FORWARD_BACKWARD_DIRECTION            		= 2
+SA_BACKWARD_FORWARD_DIRECTION            		= 3
+SA_FORWARD_DIRECTION_ABORT_ON_ENDSTOP    		= 4
+SA_BACKWARD_DIRECTION_ABORT_ON_ENDSTOP   		= 5
+SA_FORWARD_BACKWARD_DIRECTION_ABORT_ON_ENDSTOP 	= 6
+SA_BACKWARD_FORWARD_DIRECTION_ABORT_ON_ENDSTOP 	= 7
+
+# configuration values for SA_FindReferenceMark_X
+SA_NO_AUTO_ZERO                     =       0
+SA_AUTO_ZERO                        =       1
+
+# return values for SA_GetPhyscialPositionKnown_X
+SA_PHYSICAL_POSITION_UNKNOWN        =       0
+SA_PHYSICAL_POSITION_KNOWN          =       1
+
+# infinite timeout for functions that wait
+SA_TIMEOUT_INFINITE                 =       0xFFFFFFFF
+
+# sensor types for SA_SetSensorType_X and SA_GetSensorType_X
+SA_NO_SENSOR_TYPE                   =       0
+SA_S_SENSOR_TYPE                    =       1
+SA_SR_SENSOR_TYPE                   =       2
+SA_ML_SENSOR_TYPE                   =       3
+SA_MR_SENSOR_TYPE                   =       4
+SA_SP_SENSOR_TYPE                   =       5
+SA_SC_SENSOR_TYPE                   =       6
+SA_M25_SENSOR_TYPE                  =       7
+SA_SR20_SENSOR_TYPE                 =       8
+SA_M_SENSOR_TYPE                    =       9
+SA_GC_SENSOR_TYPE                   =       10
+SA_GD_SENSOR_TYPE                   =       11
+SA_GE_SENSOR_TYPE                   =       12
+SA_RA_SENSOR_TYPE                   =       13
+SA_GF_SENSOR_TYPE                   =       14
+SA_RB_SENSOR_TYPE                   =       15
+SA_G605S_SENSOR_TYPE                =       16
+SA_G775S_SENSOR_TYPE                =       17
+SA_SC500_SENSOR_TYPE                =       18
+SA_G955S_SENSOR_TYPE                =       19
+SA_SR77_SENSOR_TYPE                 =       20
+SA_SD_SENSOR_TYPE                   =       21
+SA_R20ME_SENSOR_TYPE                =       22
+SA_SR2_SENSOR_TYPE                  =       23
+SA_SCD_SENSOR_TYPE                  =       24
+SA_SRC_SENSOR_TYPE                  =       25
+SA_SR36M_SENSOR_TYPE                =       26
+SA_SR36ME_SENSOR_TYPE               =       27
+SA_SR50M_SENSOR_TYPE                =       28
+SA_SR50ME_SENSOR_TYPE               =       29
+SA_G1045S_SENSOR_TYPE               =       30
+SA_G1395S_SENSOR_TYPE               =       31
+SA_MD_SENSOR_TYPE                   =       32
+SA_G935M_SENSOR_TYPE                =       33
+SA_SHL20_SENSOR_TYPE                =       34
+SA_SCT_SENSOR_TYPE                  =       35
+SA_SR77T_SENSOR_TYPE                =       36
+SA_SR120_SENSOR_TYPE                =       37
+SA_LC_SENSOR_TYPE                   =       38
+SA_LR_SENSOR_TYPE                   =       39
+SA_LCD_SENSOR_TYPE                  =       40
+SA_L_SENSOR_TYPE                    =       41
+SA_LD_SENSOR_TYPE                   =       42
+SA_LE_SENSOR_TYPE                   =       43
+SA_LED_SENSOR_TYPE                  =       44
+SA_GDD_SENSOR_TYPE                  =       45
+SA_GED_SENSOR_TYPE                  =       46
+SA_G935S_SENSOR_TYPE                =       47
+SA_G605DS_SENSOR_TYPE               =       48
+SA_G775DS_SENSOR_TYPE               =       49
+
+# end effector types for SA_SetEndEffectorType_X and SA_GetEndEffectorType_X
+SA_ANALOG_SENSOR_END_EFFECTOR_TYPE  =       0
+SA_GRIPPER_END_EFFECTOR_TYPE        =       1
+SA_FORCE_SENSOR_END_EFFECTOR_TYPE   =       2
+SA_FORCE_GRIPPER_END_EFFECTOR_TYPE  =       3
+
+# packet types for asynchronous mode
+SA_NO_PACKET_TYPE                       =   0
+SA_ERROR_PACKET_TYPE                    =   1
+SA_POSITION_PACKET_TYPE                 =   2
+SA_COMPLETED_PACKET_TYPE                =   3
+SA_STATUS_PACKET_TYPE                   =   4
+SA_ANGLE_PACKET_TYPE                    =   5
+SA_VOLTAGE_LEVEL_PACKET_TYPE            =   6
+SA_SENSOR_TYPE_PACKET_TYPE              =   7
+SA_SENSOR_ENABLED_PACKET_TYPE           =   8
+SA_END_EFFECTOR_TYPE_PACKET_TYPE        =   9
+SA_GRIPPER_OPENING_PACKET_TYPE          =   10
+SA_FORCE_PACKET_TYPE                    =   11
+SA_MOVE_SPEED_PACKET_TYPE               =   12
+SA_PHYSICAL_POSITION_KNOWN_PACKET_TYPE  =   13
+SA_POSITION_LIMIT_PACKET_TYPE           =   14
+SA_ANGLE_LIMIT_PACKET_TYPE              =   15
+SA_SAFE_DIRECTION_PACKET_TYPE           =   16
+SA_SCALE_PACKET_TYPE                    =   17
+SA_MOVE_ACCELERATION_PACKET_TYPE        =   18
+SA_CHANNEL_PROPERTY_PACKET_TYPE         =   19
+SA_CAPTURE_BUFFER_PACKET_TYPE           =   20
+SA_TRIGGERED_PACKET_TYPE                =   21
+SA_INVALID_PACKET_TYPE                  =   255
+
+# channel status codes
+SA_STOPPED_STATUS                       =   0
+SA_STEPPING_STATUS                      =   1
+SA_SCANNING_STATUS                      =   2
+SA_HOLDING_STATUS                       =   3
+SA_TARGET_STATUS                        =   4
+SA_MOVE_DELAY_STATUS                    =   5
+SA_CALIBRATING_STATUS                   =   6
+SA_FINDING_REF_STATUS                   =   7
+SA_OPENING_STATUS                       =   8
+
+# compatibility definitions
+SA_NO_REPORT_ON_COMPLETE                =   0
+SA_REPORT_ON_COMPLETE                   =   1
+
+
+# /*******************
+# * Helper Functions *
+# *******************/
+
+# // Decode Selector Value (for some property keys)
+# MCSCONTROL_API
+# void MCSCONTROL_CC SA_DSV(signed int value, unsigned int *selector, unsigned int *subSelector);
+def SA_DSV(value, selector, subSelector):
+	MCS_lib.SA_DSV(value, ct.byref(selector), ct.byref(subSelector))
+	return
+
+# // Encode Property Key (for SA_SetChannelProperty_X and SA_GetChannelProperty_X)
+# MCSCONTROL_API
+# unsigned int MCSCONTROL_CC SA_EPK(unsigned int selector, unsigned int subSelector, unsigned int property);
+def SA_EPK(selector, subSelector, proper):
+	VAR_unsigned_int = MCS_lib.SA_EPK(selector, subSelector, proper)
+	return VAR_unsigned_int
+
+# // Encode Selector Value (for some property keys)
+# MCSCONTROL_API
+# signed int MCSCONTROL_CC SA_ESV(unsigned int selector, unsigned int subSelector);
+def SA_ESV(selector, subSelector):
+	VAR_signed_int = MCS_lib.SA_ESV(selector, subSelector)
+	return VAR_signed_int
+
+# // Transform status code into human readable string
+# MCSCONTROL_API
+# SA_STATUS MCSCONTROL_CC SA_GetStatusInfo(SA_STATUS status, const char **info);
+# Output: print('SA_GetStatusInfo: {}'.format(info.value[:].decode('utf-8')))
+# with info = ct.c_char_p() before function call
+def SA_GetStatusInfo(status, info):
+	#MCS_lib.SA_GetStatusInfo.argtypes = [ct.c_ulong, ct.POINTER(ct.c_char_p)]
+	SA_STATUS = MCS_lib.SA_GetStatusInfo(status, ct.byref(info))
+	return SA_STATUS
+
+# /************************************************************************
+# *************************************************************************
+# **                 Section I: Initialization Functions                 **
+# *************************************************************************
+# ************************************************************************/
+
+#/* new style initialization functions */
+
+#MCSCONTROL_API
+# SA_STATUS MCSCONTROL_CC SA_OpenSystem(SA_INDEX *systemIndex,const char *locator,const char *options);
+def SA_OpenSystem(systemIndex,locator,options):
+	SA_STATUS = MCS_lib.SA_OpenSystem(ct.byref(systemIndex), locator, options)
+	return SA_STATUS
+
+# #MCSCONTROL_API
+# SA_STATUS MCSCONTROL_CC SA_CloseSystem(SA_INDEX systemIndex);
+def SA_CloseSystem(systemIndex):
+	SA_STATUS = MCS_lib.SA_CloseSystem(systemIndex)
+	return SA_STATUS
+
+# #MCSCONTROL_API
+# SA_STATUS MCSCONTROL_CC SA_FindSystems(const char *options,char *outBuffer,unsigned int *ioBufferSize);
+#Works just with MCS USB versions:
+# use outBuffer = ct.create_string_buffer(17), ioBufferSize = ct.c_ulong(18)
+# to convert the outBuffer to a Python 'str' use: outBuffer[:].decode("utf-8")
+def SA_FindSystems(options,outBuffer,ioBufferSize):
+	SA_STATUS = MCS_lib.SA_FindSystems(bytes(options,'utf-8'), outBuffer,ct.byref(ioBufferSize))
+	return SA_STATUS
+
+# #MCSCONTROL_API
+# SA_STATUS MCSCONTROL_CC SA_GetSystemLocator(SA_INDEX systemIndex,char *outBuffer,unsigned int *ioBufferSize);
+# use outBuffer = ct.create_string_buffer(17), ioBufferSize = ct.c_ulong(18)
+def SA_GetSystemLocator(systemIndex, outBuffer, ioBufferSize):
+	SA_STATUS = MCS_lib.SA_GetSystemLocator(systemIndex, outBuffer, ct.byref(ioBufferSize))
+	return SA_STATUS
+
+# /* old style initialization functions */
+
+# MCSCONTROL_API
+# SA_STATUS MCSCONTROL_CC SA_AddSystemToInitSystemsList(unsigned int systemId);
+def SA_AddSystemToInitSystemsList(systemId):
+	SA_STATUS = MCS_lib.SA_AddSystemToInitSystemsList(systemId)
+	return SA_STATUS
+
+# MCSCONTROL_API
+# SA_STATUS MCSCONTROL_CC SA_ClearInitSystemsList(void);
+def SA_ClearInitSystemsList():
+	SA_STATUS = MCS_lib.SA_ClearInitSystemsList()
+	return SA_STATUS
+
+# MCSCONTROL_API
+# SA_STATUS MCSCONTROL_CC SA_GetAvailableSystems(unsigned int *idList, unsigned int *idListSize);
+def SA_GetAvailableSystems(idList, idListSize):
+	SA_STATUS = MCS_lib.SA_GetAvailableSystems(ct.byref(idList), ct.byref(idListSize))
+	return SA_STATUS
+
+# MCSCONTROL_API
+# SA_STATUS MCSCONTROL_CC SA_InitSystems(unsigned int configuration);
+def SA_InitSystems(configuration):
+	SA_STATUS = MCS_lib.SA_InitSystems(configuration)
+	return SA_STATUS
+
+# MCSCONTROL_API
+# SA_STATUS MCSCONTROL_CC SA_ReleaseSystems(void);
+def SA_ReleaseSystems():
+	SA_STATUS = MCS_lib.SA_ReleaseSystems()
+	return
+
+# MCSCONTROL_API
+# SA_STATUS MCSCONTROL_CC SA_GetInitState(unsigned int *initMode);
+def SA_GetInitState(initMode):
+	SA_STATUS = MCS_lib.SA_GetInitState(ct.byref(initMode))
+	return SA_STATUS
+
+# MCSCONTROL_API
+# SA_STATUS MCSCONTROL_CC SA_GetNumberOfSystems(unsigned int *number);
+def SA_GetNumberOfSystems(number):
+	SA_STATUS = MCS_lib.SA_GetNumberOfSystems(ct.byref(number))
+	return SA_STATUS
+
+# MCSCONTROL_API
+# SA_STATUS MCSCONTROL_CC SA_GetSystemID(SA_INDEX systemIndex, unsigned int *systemId);
+def SA_GetSystemID(systemIndex, systemId):
+	SA_STATUS = MCS_lib.SA_GetSystemID(systemIndex, ct.byref(systemId))
+	return SA_STATUS
+
+# /* --- */
+
+# MCSCONTROL_API
+# SA_STATUS MCSCONTROL_CC SA_GetChannelType(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int *type);
+def SA_GetChannelType(systemIndex, channelIndex, typ):
+	SA_STATUS = MCS_lib.SA_GetChannelType(systemIndex, channelIndex, ct.byref(typ))
+	return SA_STATUS
+
+# MCSCONTROL_API
+# SA_STATUS MCSCONTROL_CC SA_GetDLLVersion(unsigned int *version);
+def SA_GetDLLVersion(version):
+	SA_STATUS = MCS_lib.SA_GetDLLVersion(ct.byref(version))
+	return SA_STATUS
+
+# MCSCONTROL_API
+# SA_STATUS MCSCONTROL_CC SA_GetNumberOfChannels(SA_INDEX systemIndex, unsigned int *channels);
+def SA_GetNumberOfChannels(systemIndex, channels):
+	SA_STATUS = MCS_lib.SA_GetNumberOfChannels(systemIndex, ct.byref(channels))
+	return SA_STATUS
+
+# MCSCONTROL_API
+# SA_STATUS MCSCONTROL_CC SA_SetHCMEnabled(SA_INDEX systemIndex, unsigned int enabled);
+def SA_SetHCMEnabled(systemIndex, enabled):
+	SA_STATUS = MCS_lib.SA_SetHCMEnabled(systemIndex, enabled)
+	return SA_STATUS
+
+# /************************************************************************
+# *************************************************************************
+# **        Section IIa:  Functions for SYNCHRONOUS communication        **
+# *************************************************************************
+# ************************************************************************/
+
+# /*************************************************
+# **************************************************
+# **    Section IIa.1: Configuration Functions    **
+# **************************************************
+# *************************************************/
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GetAngleLimit_S(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int *minAngle, signed int *minRevolution, unsigned int *maxAngle, signed int *maxRevolution);
+def SA_GetAngleLimit_S(systemIndex, channelIndex, minAngle, minRevolution, maxAngle, maxRevolution):
+	SA_STATUS = MCS_lib.SA_GetAngleLimit_S(systemIndex, channelIndex, ct.byref(minAngle), ct.byref(minRevolution), ct.byref(maxAngle), ct.byref(maxRevolution))
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GetChannelProperty_S(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int key, signed int *value);
+def SA_GetChannelProperty_S(systemIndex, channelIndex, key, value):
+	SA_STATUS = MCS_lib.SA_GetChannelProperty_S(systemIndex, channelIndex, key, ct.byref(value))
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GetClosedLoopMoveAcceleration_S(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int *acceleration);
+def SA_GetClosedLoopMoveAcceleration_S(systemIndex, channelIndex, acceleration):
+	SA_STATUS = MCS_lib.SA_GetClosedLoopMoveAcceleration_S(systemIndex, channelIndex, ct.byref(acceleration))
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GetClosedLoopMoveSpeed_S(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int *speed);
+def SA_GetClosedLoopMoveSpeed_S(systemIndex, channelIndex, speed):
+	SA_STATUS = MCS_lib.SA_GetClosedLoopMoveSpeed_S(systemIndex, channelIndex, ct.byref(speed))
+	return SA_STATUS
+
+# MCSCONTROL_API // End effector
+# SA_STATUS MCSCONTROL_CC SA_GetEndEffectorType_S(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int *type, signed int *param1, signed int *param2);
+def SA_GetEndEffectorType_S(systemIndex, channelIndex, typ, param1, param2):
+	SA_STATUS = MCS_lib.SA_GetEndEffectorType_S(systemIndex, channelIndex, ct.byref(typ), ct.byref(param1), ct.byref(param2))
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GetPositionLimit_S(SA_INDEX systemIndex, SA_INDEX channelIndex, signed int *minPosition, signed int *maxPosition);
+def SA_GetPositionLimit_S(systemIndex, channelIndex, minPosition, maxPosition):
+	SA_STATUS = MCS_lib.SA_GetPositionLimit_S(systemIndex, channelIndex, ct.byref(minPosition), ct.byref(maxPosition))
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GetSafeDirection_S(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int *direction);
+def SA_GetSafeDirection_S(systemIndex, channelIndex, direction):
+	SA_STATUS = MCS_lib.SA_GetSafeDirection_S(systemIndex, channelIndex, ct.byref(direction))
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GetScale_S(SA_INDEX systemIndex, SA_INDEX channelIndex, signed int *scale, unsigned int *inverted);
+def SA_GetScale_S(systemIndex, channelIndex, scale, inverted):
+	SA_STATUS = MCS_lib.SA_GetScale_S(systemIndex, channelIndex, ct.byref(scale), ct.byref(inverted))
+	return SA_STATUS
+
+# MCSCONTROL_API // Global
+# SA_STATUS MCSCONTROL_CC SA_GetSensorEnabled_S(SA_INDEX systemIndex, unsigned int *enabled);
+def SA_GetSensorEnabled_S(systemIndex, enabled):
+	SA_STATUS = MCS_lib.SA_GetSensorEnabled_S(systemIndex, ct.byref(enabled))
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GetSensorType_S(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int *type);
+def SA_GetSensorType_S(systemIndex, channelIndex, typ):
+	SA_STATUS = MCS_lib.SA_GetSensorType_S(systemIndex, channelIndex, ct.byref(typ))
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_SetAccumulateRelativePositions_S(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int accumulate);
+def SA_SetAccumulateRelativePositions_S(systemIndex, channelIndex, accumulate):
+	SA_STATUS = MCS_lib.SA_SetAccumulateRelativePositions_S(systemIndex, channelIndex, accumulate)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_SetAngleLimit_S(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int minAngle, signed int minRevolution, unsigned int maxAngle, signed int maxRevolution);
+def SA_SetAngleLimit_S(systemIndex, channelIndex, minAngle, minRevolution, maxAngle, maxRevolution):
+	SA_STATUS = MCS_lib.SA_SetAngleLimit_S(systemIndex, channelIndex, minAngle, minRevolution, maxAngle, maxRevolution)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_SetChannelProperty_S(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int key, signed int value);
+def SA_SetChannelProperty_S(systemIndex, channelIndex, key, value):
+	SA_STATUS = MCS_lib.SA_SetChannelProperty_S(systemIndex, channelIndex, key, value)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_SetClosedLoopMaxFrequency_S(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int frequency);
+def SA_SetClosedLoopMaxFrequency_S(systemIndex, channelIndex, frequency):
+	SA_STATUS = MCS_lib.SA_SetClosedLoopMaxFrequency_S(systemIndex, channelIndex, frequency)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_SetClosedLoopMoveAcceleration_S(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int acceleration);
+def SA_SetClosedLoopMoveAcceleration_S(systemIndex, channelIndex, acceleration):
+	SA_STATUS = MCS_lib.SA_SetClosedLoopMoveAcceleration_S(systemIndex, channelIndex, acceleration)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_SetClosedLoopMoveSpeed_S(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int speed);
+def SA_SetClosedLoopMoveSpeed_S(systemIndex, channelIndex, speed):
+	SA_STATUS = MCS_lib.SA_SetClosedLoopMoveSpeed_S(systemIndex, channelIndex, speed)
+	return SA_STATUS
+
+# MCSCONTROL_API // End effector
+# SA_STATUS MCSCONTROL_CC SA_SetEndEffectorType_S(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int type, signed int param1, signed int param2);
+def SA_SetEndEffectorType_S(systemIndex, channelIndex, typ, param1, param2):
+	SA_STATUS = MCS_lib.SA_SetEndEffectorType_S(systemIndex, channelIndex, typ, param1, param2)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_SetPosition_S(SA_INDEX systemIndex, SA_INDEX channelIndex, signed int position);
+def SA_SetPosition_S(systemIndex, channelIndex, position):
+	SA_STATUS = MCS_lib.SA_SetPosition_S(systemIndex, channelIndex, position)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_SetPositionLimit_S(SA_INDEX systemIndex, SA_INDEX channelIndex, signed int minPosition, signed int maxPosition);
+def SA_SetPositionLimit_S(systemIndex, channelIndex, minPosition, maxPosition):
+	SA_STATUS = MCS_lib.SA_SetPositionLimit_S(systemIndex, channelIndex, minPosition, maxPosition)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_SetSafeDirection_S(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int direction);
+def SA_SetSafeDirection_S(systemIndex, channelIndex, direction):
+	SA_STATUS = MCS_lib.SA_SetSafeDirection_S(systemIndex, channelIndex, direction)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_SetScale_S(SA_INDEX systemIndex, SA_INDEX channelIndex, signed int scale, unsigned int inverted);
+def SA_SetScale_S(systemIndex, channelIndex, scale, inverted):
+	SA_STATUS = MCS_lib.SA_SetScale_S(systemIndex, channelIndex, scale, inverted)
+	return SA_STATUS
+
+# MCSCONTROL_API // Global
+# SA_STATUS MCSCONTROL_CC SA_SetSensorEnabled_S(SA_INDEX systemIndex, unsigned int enabled);
+def SA_SetSensorEnabled_S(systemIndex, enabled):
+	SA_STATUS = MCS_lib.SA_SetSensorEnabled_S(systemIndex, enabled)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_SetSensorType_S(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int type);
+def SA_SetSensorType_S(systemIndex, channelIndex, typ):
+	SA_STATUS = MCS_lib.SA_SetSensorType_S(systemIndex, channelIndex, typ)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_SetStepWhileScan_S(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int step);
+def SA_SetStepWhileScan_S(systemIndex, channelIndex, step):
+	SA_STATUS = MCS_lib.SA_SetStepWhileScan_S(systemIndex, channelIndex, step)
+	return SA_STATUS
+
+# MCSCONTROL_API // End effector
+# SA_STATUS MCSCONTROL_CC SA_SetZeroForce_S(SA_INDEX systemIndex, SA_INDEX channelIndex);
+def SA_SetZeroForce_S(systemIndex, channelIndex):
+	SA_STATUS = MCS_lib.SA_SetZeroForce_S(systemIndex, channelIndex)
+	return SA_STATUS
+
+# /*************************************************
+# **************************************************
+# **  Section IIa.2: Movement Control Functions   **
+# **************************************************
+# *************************************************/
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_CalibrateSensor_S(SA_INDEX systemIndex, SA_INDEX channelIndex);
+def SA_CalibrateSensor_S(systemIndex, channelIndex):
+	SA_STATUS = MCS_lib.SA_CalibrateSensor_S(systemIndex, channelIndex)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_FindReferenceMark_S(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int direction, unsigned int holdTime, unsigned int autoZero);
+def SA_FindReferenceMark_S(systemIndex, channelIndex, direction, holdTime, autoZero):
+	SA_STATUS = MCS_lib.SA_FindReferenceMark_S(systemIndex, channelIndex, direction, holdTime, autoZero)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GotoAngleAbsolute_S(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int angle, signed int revolution, unsigned int holdTime);
+def SA_GotoAngleAbsolute_S(systemIndex, channelIndex, angle, revolution, holdTime):
+	SA_STATUS = MCS_lib.SA_GotoAngleAbsolute_S(systemIndex, channelIndex, angle, revolution, holdTime)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GotoAngleRelative_S(SA_INDEX systemIndex, SA_INDEX channelIndex, signed int angleDiff, signed int revolutionDiff, unsigned int holdTime);
+def SA_GotoAngleRelative_S(systemIndex, channelIndex, angleDiff, revolutionDiff, holdTime):
+	SA_STATUS = MCS_lib.SA_GotoAngleRelative_S(systemIndex, channelIndex, angleDiff, revolutionDiff, holdTime)
+	return SA_STATUS
+
+# MCSCONTROL_API // End effector
+# SA_STATUS MCSCONTROL_CC SA_GotoGripperForceAbsolute_S(SA_INDEX systemIndex, SA_INDEX channelIndex, signed int force, unsigned int speed, unsigned int holdTime);
+def SA_GotoGripperForceAbsolute_S(systemIndex, channelIndex, force, speed, holdTime):
+	SA_STATUS = MCS_lib.SA_GotoGripperForceAbsolute_S(systemIndex, channelIndex, force, speed, holdTime)
+	return SA_STATUS
+
+# MCSCONTROL_API // End effector
+# SA_STATUS MCSCONTROL_CC SA_GotoGripperOpeningAbsolute_S(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int opening, unsigned int speed);
+def SA_GotoGripperOpeningAbsolute_S(systemIndex, channelIndex, opening, speed):
+	SA_STATUS = MCS_lib.SA_GotoGripperOpeningAbsolute_S(systemIndex, channelIndex, opening, speed)
+	return SA_STATUS
+
+# MCSCONTROL_API // End effector
+# SA_STATUS MCSCONTROL_CC SA_GotoGripperOpeningRelative_S(SA_INDEX systemIndex, SA_INDEX channelIndex, signed int diff, unsigned int speed);
+def SA_GotoGripperOpeningRelative_S(systemIndex, channelIndex, diff, speed):
+	SA_STATUS = MCS_lib.SA_GotoGripperOpeningRelative_S(systemIndex, channelIndex, diff, speed)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GotoPositionAbsolute_S(SA_INDEX systemIndex, SA_INDEX channelIndex, signed int position, unsigned int holdTime);
+def SA_GotoPositionAbsolute_S(systemIndex, channelIndex, position, holdTime):
+	SA_STATUS = MCS_lib.SA_GotoPositionAbsolute_S(systemIndex, channelIndex, position, holdTime)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GotoPositionRelative_S(SA_INDEX systemIndex, SA_INDEX channelIndex, signed int diff, unsigned int holdTime);
+def SA_GotoPositionRelative_S(systemIndex, channelIndex, diff, holdTime):
+	SA_STATUS = MCS_lib.SA_GotoPositionRelative_S(systemIndex, channelIndex, diff, holdTime)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_ScanMoveAbsolute_S(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int target, unsigned int scanSpeed);
+def SA_ScanMoveAbsolute_S(systemIndex, channelIndex, target, scanSpeed):
+	SA_STATUS = MCS_lib.SA_ScanMoveAbsolute_S(systemIndex, channelIndex, target, scanSpeed)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_ScanMoveRelative_S(SA_INDEX systemIndex, SA_INDEX channelIndex, signed int diff, unsigned int scanSpeed);
+def SA_ScanMoveRelative_S(systemIndex, channelIndex, diff, scanSpeed):
+	SA_STATUS = MCS_lib.SA_ScanMoveRelative_S(systemIndex, channelIndex, diff, scanSpeed)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_StepMove_S(SA_INDEX systemIndex, SA_INDEX channelIndex, signed int steps, unsigned int amplitude, unsigned int frequency);
+def SA_StepMove_S(systemIndex, channelIndex, steps, amplitude, frequency):
+	SA_STATUS = MCS_lib.SA_StepMove_S(systemIndex, channelIndex, steps, amplitude, frequency)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner, End effector
+# SA_STATUS MCSCONTROL_CC SA_Stop_S(SA_INDEX systemIndex, SA_INDEX channelIndex);
+def SA_Stop_S(systemIndex, channelIndex):
+	SA_STATUS = MCS_lib.SA_Stop_S(systemIndex, channelIndex)
+	return SA_STATUS
+
+# /************************************************
+# *************************************************
+# **  Section IIa.3: Channel Feedback Functions  **
+# *************************************************
+# *************************************************/
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GetAngle_S(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int *angle, signed int *revolution);
+def SA_GetAngle_S(systemIndex, channelIndex, angle, revolution):
+	SA_STATUS = MCS_lib.SA_GetAngle_S(systemIndex, channelIndex, ct.byref(angle), ct.byref(revolution))
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GetCaptureBuffer_S(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int bufferIndex, SA_PACKET *buffer);
+# use buffr = SA_packet() before function call to intialize the inheritance of the SA_packet class before pointing to it
+def SA_GetCaptureBuffer_S(systemIndex, channelIndex, bufferIndex, buffr):
+	MCS_lib.SA_GetCaptureBuffer_S.argtypes = [ct.c_ulong,ct.c_ulong,ct.c_ulong, ct.POINTER(SA_packet)]
+	SA_STATUS = MCS_lib.SA_GetCaptureBuffer_S(systemIndex, channelIndex, bufferIndex, buffr)
+	return SA_STATUS
+
+# MCSCONTROL_API // End effector
+# SA_STATUS MCSCONTROL_CC SA_GetForce_S(SA_INDEX systemIndex, SA_INDEX channelIndex, signed int *force);
+def SA_GetForce_S(systemIndex, channelIndex, force):
+	SA_STATUS = MCS_lib.SA_GetForce_S(systemIndex, channelIndex, ct.byref(force))
+	return SA_STATUS
+
+# MCSCONTROL_API // End effector
+# SA_STATUS MCSCONTROL_CC SA_GetGripperOpening_S(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int *opening);
+def SA_GetGripperOpening_S(systemIndex, channelIndex, opening):
+	SA_STATUS = MCS_lib.SA_GetGripperOpening_S(systemIndex, channelIndex, ct.byref(opening))
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GetPhysicalPositionKnown_S(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int *known);
+def SA_GetPhysicalPositionKnown_S(systemIndex, channelIndex, known):
+	SA_STATUS = MCS_lib.SA_GetPhysicalPositionKnown_S(systemIndex, channelIndex, ct.byref(known))
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GetPosition_S(SA_INDEX systemIndex, SA_INDEX channelIndex, signed int *position);
+def SA_GetPosition_S(systemIndex, channelIndex, position):
+	SA_STATUS = MCS_lib.SA_GetPosition_S(systemIndex, channelIndex, ct.byref(position))
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner, End effector
+# SA_STATUS MCSCONTROL_CC SA_GetStatus_S(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int *status);
+def SA_GetStatus_S(systemIndex, channelIndex, status):
+	SA_STATUS = MCS_lib.SA_GetStatus_S(systemIndex, channelIndex, ct.byref(status))
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GetVoltageLevel_S(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int *level);
+def SA_GetVoltageLevel_S(systemIndex, channelIndex, level):
+	SA_STATUS = MCS_lib.SA_GetVoltageLevel_S(systemIndex, channelIndex, ct.byref(level))
+	return SA_STATUS
+
+
+# /************************************************************************
+# *************************************************************************
+# **       Section IIb:  Functions for ASYNCHRONOUS communication        **
+# *************************************************************************
+# ************************************************************************/
+
+# /*************************************************
+# **************************************************
+# **    Section IIb.1: Configuration Functions    **
+# **************************************************
+# *************************************************/
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_AppendTriggeredCommand_A(SA_INDEX systemIndex, SA_INDEX channelIndex, signed int triggerSource);
+def SA_AppendTriggeredCommand_A(systemIndex, channelIndex, triggerSource):
+	SA_STATUS = MCS_lib.SA_AppendTriggeredCommand_A(systemIndex, channelIndex, triggerSource)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_ClearTriggeredCommandQueue_A(SA_INDEX systemIndex, SA_INDEX channelIndex);
+def SA_ClearTriggeredCommandQueue_A(systemIndex, channelIndex):
+	SA_STATUS = MCS_lib.SA_ClearTriggeredCommandQueue_A(systemIndex, channelIndex)
+	return SA_STATUS
+
+# MCSCONTROL_API
+# SA_STATUS MCSCONTROL_CC SA_FlushOutput_A(SA_INDEX systemIndex);
+def SA_FlushOutput_A(systemIndex):
+	SA_STATUS = MCS_lib.SA_FlushOutput_A(systemIndex)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GetAngleLimit_A(SA_INDEX systemIndex, SA_INDEX channelIndex);
+def SA_GetAngleLimit_A(systemIndex, channelIndex):
+	SA_STATUS = MCS_lib.SA_GetAngleLimit_A(systemIndex, channelIndex)
+	return SA_STATUS
+
+# MCSCONTROL_API
+# SA_STATUS MCSCONTROL_CC SA_GetBufferedOutput_A(SA_INDEX systemIndex, unsigned int *mode);
+def SA_GetBufferedOutput_A(systemIndex, mode):
+	SA_STATUS = MCS_lib.SA_GetBufferedOutput_A(systemIndex, ct.byref(mode))
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GetChannelProperty_A(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int key);
+def SA_GetChannelProperty_A(systemIndex, channelIndex, key):
+	SA_STATUS = MCS_lib.SA_GetChannelProperty_A(systemIndex, channelIndex, key)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GetClosedLoopMoveAcceleration_A(SA_INDEX systemIndex, SA_INDEX channelIndex);
+def SA_GetClosedLoopMoveAcceleration_A(systemIndex, channelIndex):
+	SA_STATUS = MCS_lib.SA_GetClosedLoopMoveAcceleration_A(systemIndex, channelIndex)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GetClosedLoopMoveSpeed_A(SA_INDEX systemIndex, SA_INDEX channelIndex);
+def SA_GetClosedLoopMoveSpeed_A(systemIndex, channelIndex):
+	SA_STATUS = MCS_lib.SA_GetClosedLoopMoveSpeed_A(systemIndex, channelIndex)
+	return SA_STATUS
+
+# MCSCONTROL_API // End effector
+# SA_STATUS MCSCONTROL_CC SA_GetEndEffectorType_A(SA_INDEX systemIndex, SA_INDEX channelIndex);
+def SA_GetEndEffectorType_A(systemIndex, channelIndex):
+	SA_STATUS = MCS_lib.SA_GetEndEffectorType_A(systemIndex, channelIndex)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GetPhysicalPositionKnown_A(SA_INDEX systemIndex, SA_INDEX channelIndex);
+def SA_GetPhysicalPositionKnown_A(systemIndex, channelIndex):
+	SA_STATUS = MCS_lib.SA_GetPhysicalPositionKnown_A(systemIndex, channelIndex)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GetPositionLimit_A(SA_INDEX systemIndex, SA_INDEX channelIndex);
+def SA_GetPositionLimit_A(systemIndex, channelIndex):
+	SA_STATUS = MCS_lib.SA_GetPositionLimit_A(systemIndex, channelIndex)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GetSafeDirection_A(SA_INDEX systemIndex, SA_INDEX channelIndex);
+def SA_GetSafeDirection_A(systemIndex, channelIndex):
+	SA_STATUS = MCS_lib.SA_GetSafeDirection_A(systemIndex, channelIndex)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GetScale_A(SA_INDEX systemIndex, SA_INDEX channelIndex);
+def SA_GetScale_A(systemIndex, channelIndex):
+	SA_STATUS = MCS_lib.SA_GetScale_A(systemIndex, channelIndex)
+	return SA_STATUS
+
+# MCSCONTROL_API
+# SA_STATUS MCSCONTROL_CC SA_GetSensorEnabled_A(SA_INDEX systemIndex);
+def SA_GetSensorEnabled_A(systemIndex):
+	SA_STATUS = MCS_lib.SA_GetSensorEnabled_A(systemIndex)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GetSensorType_A(SA_INDEX systemIndex, SA_INDEX channelIndex);
+def SA_GetSensorType_A(systemIndex, channelIndex):
+	SA_STATUS = MCS_lib.SA_GetSensorType_A(systemIndex, channelIndex)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_SetAccumulateRelativePositions_A(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int accumulate);
+def SA_SetAccumulateRelativePositions_A(systemIndex, channelIndex, accumulate):
+	SA_STATUS = MCS_lib.SA_SetAccumulateRelativePositions_A(systemIndex, channelIndex, accumulate)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_SetAngleLimit_A(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int minAngle, signed int minRevolution, unsigned int maxAngle, signed int maxRevolution);
+def SA_SetAngleLimit_A(systemIndex, channelIndex, minAngle, minRevolution, maxAngle, maxRevolution):
+	SA_STATUS = MCS_lib.SA_SetAngleLimit_A(systemIndex, channelIndex, minAngle, minRevolution, maxAngle, maxRevolution)
+	return SA_STATUS
+
+# MCSCONTROL_API
+# SA_STATUS MCSCONTROL_CC SA_SetBufferedOutput_A(SA_INDEX systemIndex, unsigned int mode);
+def SA_SetBufferedOutput_A(systemIndex, mode):
+	SA_STATUS = MCS_lib.SA_SetBufferedOutput_A(systemIndex, mode)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_SetChannelProperty_A(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int key, signed int value);
+def SA_SetChannelProperty_A(systemIndex, channelIndex, key, value):
+	SA_STATUS = MCS_lib.SA_SetChannelProperty_A(systemIndex, channelIndex, key, value)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_SetClosedLoopMaxFrequency_A(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int frequency);
+def SA_SetClosedLoopMaxFrequency_A(systemIndex, channelIndex, frequency):
+	SA_STATUS = MCS_lib.SA_SetClosedLoopMaxFrequency_A(systemIndex, channelIndex, frequency)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_SetClosedLoopMoveAcceleration_A(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int acceleration);
+def SA_SetClosedLoopMoveAcceleration_A(systemIndex, channelIndex, acceleration):
+	SA_STATUS = MCS_lib.SA_SetClosedLoopMoveAcceleration_A(systemIndex, channelIndex, acceleration)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_SetClosedLoopMoveSpeed_A(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int speed);
+def SA_SetClosedLoopMoveSpeed_A(systemIndex, channelIndex, speed):
+	SA_STATUS = MCS_lib.SA_SetClosedLoopMoveSpeed_A(systemIndex, channelIndex, speed)
+	return SA_STATUS
+
+# MCSCONTROL_API // End effector
+# SA_STATUS MCSCONTROL_CC SA_SetEndEffectorType_A(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int type, signed int param1, signed int param2);
+def SA_SetEndEffectorType_A(systemIndex, channelIndex, typ, param1, param2):
+	SA_STATUS = MCS_lib.SA_SetEndEffectorType_A(systemIndex, channelIndex, typ, param1, param2)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_SetPosition_A(SA_INDEX systemIndex, SA_INDEX channelIndex, signed int position);
+def SA_SetPosition_A(systemIndex, channelIndex, position):
+	SA_STATUS = MCS_lib.SA_SetPosition_A(systemIndex, channelIndex, position)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_SetPositionLimit_A(SA_INDEX systemIndex, SA_INDEX channelIndex, signed int minPosition, signed int maxPosition);
+def SA_SetPositionLimit_A(systemIndex, channelIndex, minPosition, maxPosition):
+	SA_STATUS = MCS_lib.SA_SetPositionLimit_A(systemIndex, channelIndex, minPosition, maxPosition)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner, End effector
+# SA_STATUS MCSCONTROL_CC SA_SetReportOnComplete_A(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int report);
+def SA_SetReportOnComplete_A(systemIndex, channelIndex, report):
+	SA_STATUS = MCS_lib.SA_SetReportOnComplete_A(systemIndex, channelIndex, report)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_SetReportOnTriggered_A(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int report);
+def SA_SetReportOnTriggered_A(systemIndex, channelIndex, report):
+	SA_STATUS = MCS_lib.SA_SetReportOnTriggered_A(systemIndex, channelIndex, report)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_SetSafeDirection_A(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int direction);
+def SA_SetSafeDirection_A(systemIndex, channelIndex, direction):
+	SA_STATUS = MCS_lib.SA_SetSafeDirection_A(systemIndex, channelIndex, direction)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_SetScale_A(SA_INDEX systemIndex, SA_INDEX channelIndex, signed int scale, unsigned int inverted);
+def SA_SetScale_A(systemIndex, channelIndex, scale, inverted):
+	SA_STATUS = MCS_lib.SA_SetScale_A(systemIndex, channelIndex, scale, inverted)
+	return SA_STATUS
+
+# MCSCONTROL_API
+# SA_STATUS MCSCONTROL_CC SA_SetSensorEnabled_A(SA_INDEX systemIndex, unsigned int enabled);
+def SA_SetSensorEnabled_A(systemIndex, enabled):
+	SA_STATUS = MCS_lib.SA_SetSensorEnabled_A(systemIndex, enabled)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_SetSensorType_A(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int type);
+def SA_SetSensorType_A(systemIndex, channelIndex, typ):
+	SA_STATUS = MCS_lib.SA_SetSensorType_A(systemIndex, channelIndex, typ)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_SetStepWhileScan_A(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int step);
+def SA_SetStepWhileScan_A(systemIndex, channelIndex, step):
+	SA_STATUS = MCS_lib.SA_SetStepWhileScan_A(systemIndex, channelIndex, step)
+	return SA_STATUS
+
+# MCSCONTROL_API // End effector
+# SA_STATUS MCSCONTROL_CC SA_SetZeroForce_A(SA_INDEX systemIndex, SA_INDEX channelIndex);
+def SA_SetZeroForce_A(systemIndex, channelIndex):
+	SA_STATUS = MCS_lib.SA_SetZeroForce_A(systemIndex, channelIndex)
+	return SA_STATUS
+
+# /*************************************************
+# **************************************************
+# **  Section IIb.2: Movement Control Functions   **
+# **************************************************
+# *************************************************/
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_CalibrateSensor_A(SA_INDEX systemIndex, SA_INDEX channelIndex);
+def SA_CalibrateSensor_A(systemIndex, channelIndex):
+	SA_STATUS = MCS_lib.SA_CalibrateSensor_A(systemIndex, channelIndex)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_FindReferenceMark_A(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int direction, unsigned int holdTime, unsigned int autoZero);
+def SA_FindReferenceMark_A(systemIndex, channelIndex, direction, holdTime, autoZero):
+	SA_STATUS = MCS_lib.SA_FindReferenceMark_A(systemIndex, channelIndex, direction, holdTime, autoZero)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GotoAngleAbsolute_A(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int angle, signed int revolution, unsigned int holdTime);
+def SA_GotoAngleAbsolute_A(systemIndex, channelIndex, angle, revolution, holdTime):
+	SA_STATUS = MCS_lib.SA_GotoAngleAbsolute_A(systemIndex, channelIndex, angle, revolution, holdTime)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GotoAngleRelative_A(SA_INDEX systemIndex, SA_INDEX channelIndex, signed int angleDiff, signed int revolutionDiff, unsigned int holdTime);
+def SA_GotoAngleRelative_A(systemIndex, channelIndex, angleDiff, revolutionDiff, holdTime):
+	SA_STATUS = MCS_lib.SA_GotoAngleRelative_A(systemIndex, channelIndex, angleDiff, revolutionDiff, holdTime)
+	return SA_STATUS
+
+# MCSCONTROL_API // End effector
+# SA_STATUS MCSCONTROL_CC SA_GotoGripperForceAbsolute_A(SA_INDEX systemIndex, SA_INDEX channelIndex, signed int force, unsigned int speed, unsigned int holdTime);
+def SA_GotoGripperForceAbsolute_A(systemIndex, channelIndex, force, speed, holdTime):
+	SA_STATUS = MCS_lib.SA_GotoGripperForceAbsolute_A(systemIndex, channelIndex, force, speed, holdTime)
+	return SA_STATUS
+
+# MCSCONTROL_API // End effector
+# SA_STATUS MCSCONTROL_CC SA_GotoGripperOpeningAbsolute_A(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int opening, unsigned int speed);
+def SA_GotoGripperOpeningAbsolute_A(systemIndex, channelIndex, opening, speed):
+	SA_STATUS = MCS_lib.SA_GotoGripperOpeningAbsolute_A(systemIndex, channelIndex, opening, speed)
+	return SA_STATUS
+
+# MCSCONTROL_API // End effector
+# SA_STATUS MCSCONTROL_CC SA_GotoGripperOpeningRelative_A(SA_INDEX systemIndex, SA_INDEX channelIndex, signed int diff, unsigned int speed);
+def SA_GotoGripperOpeningRelative_A(systemIndex, channelIndex, diff, speed):
+	SA_STATUS = MCS_lib.SA_GotoGripperOpeningRelative_A(systemIndex, channelIndex, diff, speed)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GotoPositionAbsolute_A(SA_INDEX systemIndex, SA_INDEX channelIndex, signed int position, unsigned int holdTime);
+def SA_GotoPositionAbsolute_A(systemIndex, channelIndex, position, holdTime):
+	SA_STATUS = MCS_lib.SA_GotoPositionAbsolute_A(systemIndex, channelIndex, position, holdTime)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GotoPositionRelative_A(SA_INDEX systemIndex, SA_INDEX channelIndex, signed int diff, unsigned int holdTime);
+def SA_GotoPositionRelative_A(systemIndex, channelIndex, diff, holdTime):
+	SA_STATUS = MCS_lib.SA_GotoPositionRelative_A(systemIndex, channelIndex, diff, holdTime)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_ScanMoveAbsolute_A(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int target, unsigned int scanSpeed);
+def SA_ScanMoveAbsolute_A(systemIndex, channelIndex, target, scanSpeed):
+	SA_STATUS = MCS_lib.SA_ScanMoveAbsolute_A(systemIndex, channelIndex, target, scanSpeed)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_ScanMoveRelative_A(SA_INDEX systemIndex, SA_INDEX channelIndex, signed int diff, unsigned int scanSpeed);
+def SA_ScanMoveRelative_A(systemIndex, channelIndex, diff, scanSpeed):
+	SA_STATUS = MCS_lib.SA_ScanMoveRelative_A(systemIndex, channelIndex, diff, scanSpeed)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_StepMove_A(SA_INDEX systemIndex, SA_INDEX channelIndex, signed int steps, unsigned int amplitude, unsigned int frequency);
+def SA_StepMove_A(systemIndex, channelIndex, steps, amplitude, frequency):
+	SA_STATUS = MCS_lib.SA_StepMove_A(systemIndex, channelIndex, steps, amplitude, frequency)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner, End effector
+# SA_STATUS MCSCONTROL_CC SA_Stop_A(SA_INDEX systemIndex, SA_INDEX channelIndex);
+def SA_Stop_A(systemIndex, channelIndex):
+	SA_STATUS = MCS_lib.SA_Stop_A(systemIndex, channelIndex)
+	return SA_STATUS
+
+# MCSCONTROL_API
+# SA_STATUS MCSCONTROL_CC SA_TriggerCommand_A(SA_INDEX systemIndex, unsigned int triggerIndex);
+def SA_TriggerCommand_A(systemIndex, triggerIndex):
+	SA_STATUS = MCS_lib.SA_TriggerCommand_A(systemIndex, triggerIndex)
+	return SA_STATUS
+
+# /************************************************
+# *************************************************
+# **  Section IIb.3: Channel Feedback Functions  **
+# *************************************************
+# ************************************************/
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GetAngle_A(SA_INDEX systemIndex, SA_INDEX channelIndex);
+def SA_GetAngle_A(systemIndex, channelIndex):
+	SA_STATUS = MCS_lib.SA_GetAngle_A(systemIndex, channelIndex)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GetCaptureBuffer_A(SA_INDEX systemIndex, SA_INDEX channelIndex, unsigned int bufferIndex);
+def SA_GetCaptureBuffer_A(systemIndex, channelIndex, bufferIndex):
+	SA_STATUS = MCS_lib.SA_GetCaptureBuffer_A(systemIndex, channelIndex, bufferIndex)
+	return SA_STATUS
+
+# MCSCONTROL_API // End effector
+# SA_STATUS MCSCONTROL_CC SA_GetForce_A(SA_INDEX systemIndex, SA_INDEX channelIndex);
+def SA_GetForce_A(systemIndex, channelIndex):
+	SA_STATUS = MCS_lib.SA_GetForce_A(systemIndex, channelIndex)
+	return SA_STATUS
+
+# MCSCONTROL_API // End effector
+# SA_STATUS MCSCONTROL_CC SA_GetGripperOpening_A(SA_INDEX systemIndex, SA_INDEX channelIndex);
+def SA_GetGripperOpening_A(systemIndex, channelIndex):
+	SA_STATUS = MCS_lib.SA_GetGripperOpening_A(systemIndex, channelIndex)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GetPosition_A(SA_INDEX systemIndex, SA_INDEX channelIndex);
+def SA_GetPosition_A(systemIndex, channelIndex):
+	SA_STATUS = MCS_lib.SA_GetPosition_A(systemIndex, channelIndex)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner, End effector
+# SA_STATUS MCSCONTROL_CC SA_GetStatus_A(SA_INDEX systemIndex, SA_INDEX channelIndex);
+def SA_GetStatus_A(systemIndex, channelIndex):
+	SA_STATUS = MCS_lib.SA_GetStatus_A(systemIndex, channelIndex)
+	return SA_STATUS
+
+# MCSCONTROL_API // Positioner
+# SA_STATUS MCSCONTROL_CC SA_GetVoltageLevel_A(SA_INDEX systemIndex, SA_INDEX channelIndex);
+def SA_GetVoltageLevel_A(systemIndex, channelIndex):
+	SA_STATUS = MCS_lib.SA_GetVoltageLevel_A(systemIndex, channelIndex)
+	return SA_STATUS
+
+# /******************
+# * Answer retrieval
+# ******************/
+# MCSCONTROL_API
+# SA_STATUS MCSCONTROL_CC SA_DiscardPacket_A(SA_INDEX systemIndex);
+def SA_DiscardPacket_A(systemIndex):
+	SA_STATUS = MCS_lib.SA_DiscardPacket_A(systemIndex)
+	return SA_STATUS
+
+# MCSCONTROL_API
+# SA_STATUS MCSCONTROL_CC SA_LookAtNextPacket_A(SA_INDEX systemIndex, unsigned int timeout, SA_PACKET *packet);
+# use packet = SA_packet() before function call to intialize the inheritance of the SA_packet class before pointing to it
+def SA_LookAtNextPacket_A(systemIndex, timeout, packet):
+	MCS_lib.SA_LookAtNextPacket_A.argtypes = [ct.c_ulong, ct.c_ulong, ct.POINTER(SA_packet)]
+	SA_STATUS = MCS_lib.SA_LookAtNextPacket_A(systemIndex, timeout, packet)
+	return SA_STATUS
+
+# MCSCONTROL_API
+# SA_STATUS MCSCONTROL_CC SA_ReceiveNextPacket_A(SA_INDEX systemIndex, unsigned int timeout, SA_PACKET *packet);
+# use packet = SA_packet() before function call to intialize the inheritance of the SA_packet class before pointing to it
+def SA_ReceiveNextPacket_A(systemIndex, timeout, packet):
+	MCS_lib.SA_ReceiveNextPacket_A.argtypes = [ct.c_ulong, ct.c_ulong, ct.POINTER(SA_packet)]
+	SA_STATUS = MCS_lib.SA_ReceiveNextPacket_A(systemIndex, timeout, packet)
+	return SA_STATUS
+
+# MCSCONTROL_API
+# SA_STATUS MCSCONTROL_CC SA_CancelWaitForPacket_A(SA_INDEX systemIndex);
+def SA_CancelWaitForPacket_A(systemIndex):
+	SA_STATUS = MCS_lib.SA_CancelWaitForPacket_A(systemIndex)
+	return SA_STATUS
+
+
+

--- a/imswitch/imcontrol/model/managers/detectors/PhotometricsManager.py
+++ b/imswitch/imcontrol/model/managers/detectors/PhotometricsManager.py
@@ -29,7 +29,7 @@ class PhotometricsManager(DetectorManager):
         self.__acquisition = False
         # Prepare parameters
         parameters = {
-            'Set exposure time': DetectorNumberParameter(group='Timings', value=0,
+            'Set exposure time': DetectorNumberParameter(group='Timings', value=1,
                                                          valueUnits='ms', editable=True),
             'Real exposure time': DetectorNumberParameter(group='Timings', value=0,
                                                           valueUnits='ms', editable=False),
@@ -55,8 +55,14 @@ class PhotometricsManager(DetectorManager):
         super().__init__(detectorInfo, name, fullShape=fullShape, supportedBinnings=[1, 2, 4],
                          model=model, parameters=parameters, croppable=True)
         self._updatePropertiesFromCamera()
-        super().setParameter('Set exposure time', self.parameters['Real exposure time'].value)
 
+        super().setParameter('Set exposure time', self.parameters['Real exposure time'].value)
+        if 'Photometrics' in detectorInfo.managerProperties:
+            # Update the user-specific settings
+            for key, value in detectorInfo.managerProperties['Photometrics'].items():
+                self.__logger.info(f'Updating user-supplied value for {key}')
+                self.setParameter(key, value)
+            self._updatePropertiesFromCamera()
     @property
     def pixelSizeUm(self):
         umxpx = self.parameters['Camera pixel size'].value

--- a/imswitch/imcontrol/model/managers/positioners/SmarACTPositionerManager.py
+++ b/imswitch/imcontrol/model/managers/positioners/SmarACTPositionerManager.py
@@ -29,6 +29,23 @@ class SmarACTPositionerManager(PositionerManager):
 
     It is based on the unofficial wrapper of the MCS2 stages. Newer stages may need more things.
 
+    Known issues:
+        - The stage will not gracefully exit when resetOnClose is set to True.
+
+    Example json file configuration:
+        "positioners": {
+      "SmarACT": {
+          "managerName": "SmarACTPositionerManager",
+          "managerProperties": {
+            "holdTime": 60000,
+            "axis_lookup_table": {"X":0, "Y":2, "Z":1}
+          },
+          "axes": ["X", "Y", "Z"],
+          "forScanning": false,
+          "forPositioning": true,
+          "resetOnClose": false
+      }
+
 
 
     Manager properties:

--- a/imswitch/imcontrol/model/managers/positioners/SmarACTPositionerManager.py
+++ b/imswitch/imcontrol/model/managers/positioners/SmarACTPositionerManager.py
@@ -1,0 +1,286 @@
+import time
+from typing import Dict
+import numpy as np
+import logging
+logging.basicConfig(level=logging.DEBUG)
+from .PositionerManager import PositionerManager
+from ..detectors.DetectorManager import DetectorNumberParameter
+
+try:
+    from imswitch.imcontrol.model.interfaces.SmarACT import *
+except ImportError:
+    print('Could not import smaract interface!')
+    raise
+
+
+import ctypes as ct
+MU2NM = 1e3 # micrometer to nanometer
+
+
+class StageStatusException(BaseException):
+    """Custom exception"""
+    pass
+
+
+class SmarACTPositionerManager(PositionerManager):
+    """ SmarACT Positioner manager.
+
+    Manager properties:
+
+    None
+    """
+
+    tol_nm = 10
+    holdTime_ms = 60_000
+
+    def __init__(self, positionerInfo, name, **lowLevelManagers):
+
+        super().__init__(positionerInfo, name, initialPosition={
+            axis: 0 for axis in positionerInfo.axes
+        })
+        self.axis_lookup_table = dict(X=0, Y=2, Z=1)
+        self.reverse_axis_lookup_table = {}
+        for key, value in self.axis_lookup_table.items():
+            self.reverse_axis_lookup_table[value] = key
+
+
+        self.__logger__ = logging.getLogger(self.name)
+        self.__logger__.setLevel(logging.DEBUG)
+        self.__logger__.debug('Connecting to stage')
+        self.__setup_connection_and_buffers()
+        self.__logger__.debug('Connected to stage')
+
+    def ExitIfError(self, status):
+        # init error_msg variable
+        error_msg = ct.c_char_p()
+        if status != SA_OK:
+            SA_GetStatusInfo(status, error_msg)
+            error_message = (
+                f"MCS error: {error_msg.value[:].decode('utf-8')} \n Err code {status}"
+            )
+            self.__logger__.error(error_message)
+            raise StageStatusException(error_message)
+        return status
+
+    def __setup_connection_and_buffers(self):
+        """ Internal use only. Connect to the device and set up a buffer to receive replies.
+        """
+        self.mcsHandle = ct.c_ulong()
+        self.outBuffer = ct.create_string_buffer(17)
+        self.ioBufferSize = ct.c_ulong(18)
+        self.ExitIfError(
+            SA_FindSystems("", self.outBuffer, self.ioBufferSize)
+        )
+        self.ExitIfError(
+            SA_OpenSystem(self.mcsHandle, self.outBuffer, bytes("sync", "utf-8"))
+        )
+        self.__logger__.info(
+            "MCS address: {}".format(self.outBuffer[:18].decode("utf-8")))  # connect to first system of list
+
+    def finalize(self):
+        """ Disconnect the device.
+
+        """
+        self.__logger__.info('Closing system')
+        self.ExitIfError(SA_CloseSystem(self.mcsHandle))
+
+
+    def move(self, dist, axis):
+        """
+        Move axis axis by a distance.
+
+        Params:
+            dist: distance in microns
+            axis: axis to move. Should be in ['X', 'Y', 'Z']
+        """
+
+        current_position = self.getPosition(axis=axis)
+        self.__logger__.info(f'Moving axis {axis} by {dist}. Current position {current_position}')
+        new_position = current_position + dist
+        self.setPosition(new_position, axis)
+
+    def getPosition(self, axis):
+        return self._get_position_channel(self.axis_lookup_table[axis])
+
+    def setPosition(self, position: float, axis: str, wait_for_it=True):
+        self.__logger__.info(f'Moving axis {axis} to {position}')
+        axis_num = self.axis_lookup_table[axis]
+        t = position * MU2NM
+        self.ExitIfError(
+            SA_GotoPositionAbsolute_S(
+                self.mcsHandle,
+                channelIndex=axis_num,
+                position=ct.c_int(int(t)),
+                holdTime=ct.c_ulong(self.holdTime_ms),
+            )
+        )
+        if wait_for_it:
+            self.wait_for_status()
+
+
+    def set_closed_loop_max_speed(self, new_value, channel=None):
+        """Set closed loop max speed, in mm per second"""
+        new_value, channel = self._prepare_fancy_broadcasting(
+            new_value, channel, MU2NM
+        )
+        for c, v in zip(channel, new_value):
+            self.ExitIfError(
+                SA_SetClosedLoopMoveSpeed_S(self.mcsHandle, c, ct.c_uint32(v))
+            )
+            # get it and check that it works
+            set_val = self.get_closed_loop_move_speed(c)
+            assert (
+                set_val == v
+            ), f"Could not set closed loop move speed. Requested {new_value}, got {set_val}"
+
+    def _prepare_fancy_broadcasting(
+        self, new_value, channel=None, conversion_factor=MU2NM
+    ):
+        """
+        Internal use only. Do a numpy-like broadcasting for axes and scalars.
+
+        This is to make it easy to change the speed per axis.
+        """
+        new_value = np.array(new_value)
+        new_value = np.array(new_value * MU2NM, dtype=np.uint32)
+        if len(new_value.ravel()) == 1:
+            new_value = [
+                new_value,
+            ] * 3
+        if channel is None:
+            channel = range(3)
+        if np.isscalar(channel):
+            channel = [channel]
+        return new_value, channel
+
+    def set_closed_loop_move_acceleration(self, new_value, channel=None):
+        """Set acceleration in mm/s^2"""
+        new_value, channel = self._prepare_fancy_broadcasting(
+            new_value, channel, MU2NM
+        )
+
+        for c, v in zip(channel, new_value):
+            self.ExitIfError(
+                SA_SetClosedLoopMoveAcceleration_S(self.mcsHandle, c, ct.c_uint32(v))
+            )
+            # get it and check that it works
+            set_val = self.get_closed_loop_move_acelleration(c)
+            assert (
+                set_val == v
+            ), f"Could not set closed loop move acelleration. Requested {new_value}, got {set_val}"
+
+    def get_closed_loop_move_acelleration(self, channel):
+        accel = ct.c_uint32(0)
+        self.ExitIfError(
+            SA_GetClosedLoopMoveAcceleration_S(self.mcsHandle, channel, accel)
+        )
+        return accel.value
+
+    def get_closed_loop_move_speed(self, channel):
+        speed = ct.c_uint32(0)
+        self.ExitIfError(SA_GetClosedLoopMoveSpeed_S(self.mcsHandle, channel, speed))
+        return speed.value
+
+    def set_low_vibration_mode(self, channels=None):
+        if channels is None:
+            channels = range(3)
+        for channel in channels:
+            self.ExitIfError(
+                SA_SetChannelProperty_S(
+                    self.mcsHandle,
+                    channel,
+                    SA_EPK(SA_GENERAL, SA_LOW_VIBRATION, SA_OPERATION_MODE),
+                    SA_ENABLED,
+                )
+            )
+
+    @property
+    def position(self) -> Dict[str, float]:
+        self.axis_lookup_table.items()
+        pos = np.array([self.getPosition(a) for a in 'XYZ'])
+        positions = {}
+        for ax, p in zip(self.axes, pos):
+            positions[ax] = p
+        return positions
+
+    def _get_position_channel(self, channel):
+        """Get position for channel channel. """
+        x_cor = ct.c_ulong()
+        self.ExitIfError(SA_GetPosition_S(self.mcsHandle, ct.c_ulong(channel), x_cor))
+        return self.c_convert(x_cor.value) / MU2NM
+
+    def wait_for_status(self, target_statuses=(SA_STOPPED_STATUS, SA_HOLDING_STATUS)):
+        """Wait for the stage to reach status X.
+        X can be an array or a single state."""
+        if type(target_statuses) is int:
+            target_statuses = np.array([target_statuses])
+        else:
+            target_statuses = np.array(target_statuses)
+
+        while True:
+            states = self.get_status()
+            # check that all the axes are in the right state. First we check that the state
+            # corresponds to any state we accept for all axes, and then we check that all axes match
+            if np.all(np.any(states == target_statuses[:, None], axis=0)):
+                break
+            time.sleep(0.1)
+
+    def get_status(self):
+        """Get status for all three channels."""
+        status = ct.c_ulong()
+        states = np.zeros(3, int)
+        for channel in range(3):
+            self.ExitIfError(SA_GetStatus_S(self.mcsHandle, channel, status))
+            states[channel] = int(status.value)
+        return states
+
+    def _start_moving(self, position):
+        """Start moving to a position. This command will not wait for the movement to complete."""
+
+        for i, t in enumerate(position * MU2NM):
+
+            self.ExitIfError(
+                SA_GotoPositionAbsolute_S(
+                    self.mcsHandle,
+                    ct.c_ulong(i),
+                    ct.c_int(int(t)),
+                    ct.c_ulong(self.holdTime_ms),
+                )
+            )
+
+    def ExitIfError(self, status):
+        # init error_msg variable
+        error_msg = ct.c_char_p()
+        if status != SA_OK:
+            SA_GetStatusInfo(status, error_msg)
+            error_message = (
+                f"MCS error: {error_msg.value[:].decode('utf-8')} \n Err code {status}"
+            )
+            self.__logger__.error(error_message)
+            raise StageStatusException(error_message)
+        return status
+
+    def c_convert(self, xx):
+        "converts the ctype minus int values into python int value"
+        if xx >> 31 > 0:
+            mask = 0xFFFFFFFF
+            xx = -xx ^ mask
+        return xx
+
+
+
+# Copyright (C) 2020-2021 ImSwitch developers
+# This file is part of ImSwitch.
+#
+# ImSwitch is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ImSwitch is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.


### PR DESCRIPTION
This adds smaract stage hardware control for MCS version 1 (the old style). As I do not have a newer stage I cannot test with it.

I contacted smarACT to check if this is the right way to drive the stage, and they think it should work. I've attached their response below. 

There are one or two issues, mainly that to start, I have to provide the initial position of the stage, but when I do, I do not know that yet. At the moment that means that the stage is set to 0,0,0, although that may not be correct. As far as I can see, it should be updated as soon as you press a button.

I also added some documentation on how to set up the config file, so it's easier to set up.


---



> Dear Dirk

> 
> 
> Our team has evaluated the wrapper - thank you for forwarding it!
> 
> We could not find any issues. What we did notice, is that while the wrapper is kept simple with setting the maxCLF for point to point movements, commands such as setting the positioner typ, calibratipn and referencing are not implemented to the wrapper, so that this needs to be done in advance using the controller or directly in imswitch.
> We also provide an unoffical MCS1 python wrapper which I am adding for your overview. The only inconvenience we can think of in future is when upgrading our deprecated MCS1 series to the MCS2 while running the MCS2 on the old python version. This may not allow for all the features the MCS2 provides.
> 
> In any case, you can definitely use implementation. 
